### PR TITLE
Small Quality of Life improvements

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use_flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,14 @@
+
+# cache directories
 **/.mypy_cache
+**/.cache
+
+# build directories
+**/target
+**/result
+
+# system debris
+**/.DS_Store
+**/.directory
+**/.Trash*
+**/desktop.ini

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 # cache directories
 **/.mypy_cache
+**/.direnv
 **/.cache
 
 # build directories

--- a/flake.nix
+++ b/flake.nix
@@ -1,17 +1,20 @@
 {
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
         pkgs = nixpkgs.legacyPackages.${system};
         python312-debug = pkgs.python312.overrideAttrs (self: super: {
           configureFlags = super.configureFlags ++ ["--with-pydebug"];
         });
-      in
-      {
+      in {
         packages = {
-          python-dbg = (python312-debug.withPackages (pypkgs: [
+          python-dbg = python312-debug.withPackages (pypkgs: [
             pypkgs.typer
             pypkgs.pycparser
             pypkgs.pytest
@@ -19,7 +22,7 @@
             pypkgs.pygraphviz
             pypkgs.networkx
             pypkgs.ipython
-          ]));
+          ]);
         };
         devShells = {
           default = pkgs.mkShell {
@@ -38,6 +41,7 @@
               pkgs.coreutils
               pkgs.bash
               pkgs.xdot
+              pkgs.alejandra
             ];
           };
         };

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/a3rp7xir1zrspf26knhw2s8w7bc114ml-python3-3.12.3-env


### PR DESCRIPTION
This PR does three minor things:

1. Expands the `.gitignore` to include some additional paths that should probably be ignored (see [commit message](https://github.com/charmoniumQ/PROBE/commit/fa9f6ed1bdd4502cbcdad21f97f7facd2af08d26) for individual explanations).
2. Adds an `.envrc` file that hooks the devShell so that it automatically gets loaded on directory entry.
3. Formats `flake.nix` with the [`alejandra`](https://github.com/kamadorueda/alejandra) formatter, and adds it to the devShell

The last point is very opinionated, but my rationale for picking alejandra over nixpkgs-fmt is that it produces smaller file diffs, and (in my opinion) is easier to read nix code than nixpkgs-fmt.