### PR TITLE
Added flags to build libprobe.so freestanding

### DIFF
--- a/probe_src/libprobe/Makefile
+++ b/probe_src/libprobe/Makefile
@@ -1,6 +1,7 @@
 SOURCE_VERSION ?= $(shell git rev-parse --short HEAD)
-DBGCFLAGS ?= -DSOURCE_VERSION=\"$(SOURCE_VERSION)\" -Wno-cast-function-type -Wno-array-parameter -ffreestanding -Wl,--as-needed -ldl -Wall -Wextra -pthread -Og -g
-OPTCFLAGS ?= -DSOURCE_VERSION=\"$(SOURCE_VERSION)\" -Wno-cast-function-type -Wno-array-parameter -ffreestanding -Wl,--as-needed -Wall -Wextra -pthread -O3 -DNDEBUG
+CFLAGS ?= -DSOURCE_VERSION=\"$(SOURCE_VERSION)\" -Wno-cast-function-type -Wno-array-parameter -ffreestanding -Wl,--as-needed -Wall -Wextra -pthread
+DBGCFLAGS ?= $(CFLAGS) -Og -g
+OPTCFLAGS ?= $(CFLAGS) -O3 -DNDEBUG
 LIBCFLAGS ?= -fPIC -nostdlib -shared
 SOURCE_FILES := $(wildcard src/*.c) $(wildcard include/*.h)
 

--- a/probe_src/libprobe/Makefile
+++ b/probe_src/libprobe/Makefile
@@ -1,7 +1,7 @@
 SOURCE_VERSION ?= $(shell git rev-parse --short HEAD)
-DBGCFLAGS ?= -DSOURCE_VERSION=\"$(SOURCE_VERSION)\" -Wno-cast-function-type -Wno-array-parameter -ldl -Wall -Wextra -pthread -Og -g
-OPTCFLAGS ?= -DSOURCE_VERSION=\"$(SOURCE_VERSION)\" -Wno-cast-function-type -Wno-array-parameter -ldl -Wall -Wextra -pthread -O3 -DNDEBUG
-LIBCFLAGS ?= -fPIC -shared
+DBGCFLAGS ?= -DSOURCE_VERSION=\"$(SOURCE_VERSION)\" -Wno-cast-function-type -Wno-array-parameter -ffreestanding -Wl,--as-needed -ldl -Wall -Wextra -pthread -Og -g
+OPTCFLAGS ?= -DSOURCE_VERSION=\"$(SOURCE_VERSION)\" -Wno-cast-function-type -Wno-array-parameter -ffreestanding -Wl,--as-needed -Wall -Wextra -pthread -O3 -DNDEBUG
+LIBCFLAGS ?= -fPIC -nostdlib -shared
 SOURCE_FILES := $(wildcard src/*.c) $(wildcard include/*.h)
 
 GENERATED_FILES := generated/libc_hooks.c generated/libc_hooks.h


### PR DESCRIPTION
I would love to say I have a perfect understanding of the implications of this change, but I don't. I think it should be fine for any executable that links libc, but I can't say that with 100% certainty.