### PR TITLE
Fix `SIGSEGV` bugs in libprobe

### DIFF
--- a/probe_src/libprobe/generated/libc_hooks.c
+++ b/probe_src/libprobe/generated/libc_hooks.c
@@ -423,7 +423,7 @@ DIR * opendir(const char *dirname)
   if (likely(prov_log_is_enabled()))
   {
     op.data.open.ferrno = (ret == NULL) ? (errno) : (0);
-    op.data.open.fd = dirfd(ret);
+    op.data.open.fd = try_dirfd(ret);
     prov_log_record(op);
   }
   errno = saved_errno;
@@ -443,7 +443,7 @@ DIR * fdopendir(int fd)
   if (likely(prov_log_is_enabled()))
   {
     op.data.open.ferrno = (ret == NULL) ? (errno) : (0);
-    op.data.open.fd = dirfd(ret);
+    op.data.open.fd = try_dirfd(ret);
     prov_log_record(op);
   }
   errno = saved_errno;
@@ -453,7 +453,7 @@ DIR * fdopendir(int fd)
 struct dirent * readdir(DIR *dirstream)
 {
   maybe_init_thread();
-  int fd = dirfd(dirstream);
+  int fd = try_dirfd(dirstream);
   struct Op op = {readdir_op_code, {.readdir = {.dir = create_path_lazy(fd, "", AT_EMPTY_PATH), .child = NULL, .all_children = false, .ferrno = 0}}, {0}};
   if (likely(prov_log_is_enabled()))
   {
@@ -480,7 +480,7 @@ struct dirent * readdir(DIR *dirstream)
 int readdir_r(DIR *dirstream, struct dirent *entry, struct dirent **result)
 {
   maybe_init_thread();
-  int fd = dirfd(dirstream);
+  int fd = try_dirfd(dirstream);
   struct Op op = {readdir_op_code, {.readdir = {.dir = create_path_lazy(fd, "", AT_EMPTY_PATH), .child = NULL, .all_children = false, .ferrno = 0}}, {0}};
   if (likely(prov_log_is_enabled()))
   {
@@ -507,7 +507,7 @@ int readdir_r(DIR *dirstream, struct dirent *entry, struct dirent **result)
 struct dirent64 * readdir64(DIR *dirstream)
 {
   maybe_init_thread();
-  int fd = dirfd(dirstream);
+  int fd = try_dirfd(dirstream);
   struct Op op = {readdir_op_code, {.readdir = {.dir = create_path_lazy(fd, "", AT_EMPTY_PATH), .child = NULL, .all_children = false, .ferrno = 0}}, {0}};
   if (likely(prov_log_is_enabled()))
   {
@@ -534,7 +534,7 @@ struct dirent64 * readdir64(DIR *dirstream)
 int readdir64_r(DIR *dirstream, struct dirent64 *entry, struct dirent64 **result)
 {
   maybe_init_thread();
-  int fd = dirfd(dirstream);
+  int fd = try_dirfd(dirstream);
   struct Op op = {readdir_op_code, {.readdir = {.dir = create_path_lazy(fd, "", AT_EMPTY_PATH), .child = NULL, .all_children = false, .ferrno = 0}}, {0}};
   if (likely(prov_log_is_enabled()))
   {
@@ -561,7 +561,7 @@ int readdir64_r(DIR *dirstream, struct dirent64 *entry, struct dirent64 **result
 int closedir(DIR *dirstream)
 {
   maybe_init_thread();
-  int fd = dirfd(dirstream);
+  int fd = try_dirfd(dirstream);
   struct Op op = {close_op_code, {.close = {fd, fd, 0}}, {0}};
   if (likely(prov_log_is_enabled()))
   {

--- a/probe_src/libprobe/generator/libc_hooks_source.c
+++ b/probe_src/libprobe/generator/libc_hooks_source.c
@@ -415,7 +415,7 @@ DIR * opendir (const char *dirname) {
     void* post_call = ({
         if (likely(prov_log_is_enabled())) {
             op.data.open.ferrno = ret == NULL ? errno : 0;
-            op.data.open.fd = dirfd(ret);
+            op.data.open.fd = try_dirfd(ret);
             prov_log_record(op);
         }
     });
@@ -441,7 +441,7 @@ DIR * fdopendir (int fd) {
     void* post_call = ({
         if (likely(prov_log_is_enabled())) {
             op.data.open.ferrno = ret == NULL ? errno : 0;
-            op.data.open.fd = dirfd(ret);
+            op.data.open.fd = try_dirfd(ret);
             prov_log_record(op);
         }
     });
@@ -451,7 +451,7 @@ DIR * fdopendir (int fd) {
 /* https://www.gnu.org/software/libc/manual/html_node/Reading_002fClosing-Directory.html */
 struct dirent * readdir (DIR *dirstream) {
     void* pre_call = ({
-        int fd = dirfd(dirstream);
+        int fd = try_dirfd(dirstream);
         struct Op op = {
             readdir_op_code,
             {.readdir = {
@@ -482,7 +482,7 @@ struct dirent * readdir (DIR *dirstream) {
 }
 int readdir_r (DIR *dirstream, struct dirent *entry, struct dirent **result) {
     void* pre_call = ({
-        int fd = dirfd(dirstream);
+        int fd = try_dirfd(dirstream);
         struct Op op = {
             readdir_op_code,
             {.readdir = {
@@ -513,7 +513,7 @@ int readdir_r (DIR *dirstream, struct dirent *entry, struct dirent **result) {
 }
 struct dirent64 * readdir64 (DIR *dirstream) {
     void* pre_call = ({
-        int fd = dirfd(dirstream);
+        int fd = try_dirfd(dirstream);
         struct Op op = {
             readdir_op_code,
             {.readdir = {
@@ -544,7 +544,7 @@ struct dirent64 * readdir64 (DIR *dirstream) {
 }
 int readdir64_r (DIR *dirstream, struct dirent64 *entry, struct dirent64 **result) {
     void* pre_call = ({
-        int fd = dirfd(dirstream);
+        int fd = try_dirfd(dirstream);
         struct Op op = {
             readdir_op_code,
             {.readdir = {
@@ -575,7 +575,7 @@ int readdir64_r (DIR *dirstream, struct dirent64 *entry, struct dirent64 **resul
 }
 int closedir (DIR *dirstream) {
     void* pre_call = ({
-        int fd = dirfd(dirstream);
+        int fd = try_dirfd(dirstream);
         struct Op op = {
             close_op_code,
             {.close = {fd, fd, 0}},

--- a/probe_src/libprobe/src/prov_ops.c
+++ b/probe_src/libprobe/src/prov_ops.c
@@ -15,11 +15,12 @@ static struct Path create_path_lazy(int dirfd, BORROWED const char* path, int fl
         /*
          * If path is empty string, AT_EMPTY_PATH should probably be set.
          * I can't think of a counterexample that isn't some kind of error.
+         * However, some functions permit passing NULL.
          *
          * Then again, this could happen in the tracee's code too...
          * TODO: Remove this once I debug myself.
          * */
-        assert(path[0] != '\0' || flags & AT_EMPTY_PATH);
+        assert(path == NULL || path[0] != '\0' || flags & AT_EMPTY_PATH);
 
         /*
          * if path == NULL, then the target is the dir specified by dirfd.

--- a/probe_src/libprobe/src/util.c
+++ b/probe_src/libprobe/src/util.c
@@ -218,6 +218,17 @@ static OWNED const char* dirfd_path(int dirfd) {
     return ret;
 }
 
+/*
+ * dirfd(3) is not tolerant of NULL:
+ * header: https://github.com/bminor/glibc/blob/9fc639f654dc004736836613be703e6bed0c36a8/dirent/dirent.h#L226
+ * src: https://github.com/bminor/glibc/blob/9fc639f654dc004736836613be703e6bed0c36a8/sysdeps/unix/sysv/linux/dirfd.c#L27
+ *
+ * -1 is never a valid fd because it's the error value for syscalls that return fds, so we can do the same.
+ */
+static int try_dirfd(BORROWED DIR* dirp) {
+    return (dirp != NULL) ? (dirfd(dirp)) : (-1);
+}
+
 #ifndef NDEBUG
 static int fd_is_valid(int fd) {
     return unwrapped_fcntl(fd, F_GETFD) != -1 || errno != EBADF;


### PR DESCRIPTION
Fixes two bugs which allowed NULL pointers to be dereferenced under certain circumstances.

1. Some filesystem related functions permit passing NULL as a file path, [this assertion](https://github.com/charmoniumQ/PROBE/blob/5042816c8ab7fe94554c270ecee83fe7edafb5c9/probe_src/libprobe/src/prov_ops.c#L22) failed to check if the path was NULL before dereferencing it with the array subscript operator. 
2. While POSIX.1-2008 does specify an error (EINVAL) to be returned when direnv(3) is passed an invalid directory stream, the [current glibc implementation](https://github.com/bminor/glibc/blob/master/sysdeps/unix/sysv/linux/dirfd.c#L27) is not NULL tolerant, so each call to `dirfd()` has been replaced with a call to a new function `try_dirfd()` which returns `-1` if the directory stream is NULL (since `-1` is never a valid file descriptor).