### PR TITLE
Fixed SIGSEGV in wait(2)

### DIFF
--- a/probe_src/libprobe/generated/libc_hooks.c
+++ b/probe_src/libprobe/generated/libc_hooks.c
@@ -1923,6 +1923,11 @@ int clone(fn_ptr_int_void_ptr fn, void *stack, int flags, void *arg, ...)
 pid_t waitpid(pid_t pid, int *status_ptr, int options)
 {
   maybe_init_thread();
+  int status;
+  if (status_ptr == NULL)
+  {
+    status_ptr = &status;
+  }
   struct Op op = {wait_op_code, {.wait = {.task_type = TASK_TID, .task_id = 0, .options = options, .status = 0, .ferrno = 0}}, {0}};
   prov_log_try(op);
   pid_t ret = unwrapped_waitpid(pid, status_ptr, options);
@@ -1947,6 +1952,11 @@ pid_t waitpid(pid_t pid, int *status_ptr, int options)
 pid_t wait(int *status_ptr)
 {
   maybe_init_thread();
+  int status;
+  if (status_ptr == NULL)
+  {
+    status_ptr = &status;
+  }
   struct Op op = {wait_op_code, {.wait = {.task_type = TASK_PID, .task_id = -1, .options = 0, .status = 0, .ferrno = 0}}, {0}};
   prov_log_try(op);
   pid_t ret = unwrapped_wait(status_ptr);

--- a/probe_src/libprobe/generator/libc_hooks_source.c
+++ b/probe_src/libprobe/generator/libc_hooks_source.c
@@ -1991,6 +1991,10 @@ int clone(
 /* Docs: https://www.gnu.org/software/libc/manual/html_node/Process-Completion.html */
 pid_t waitpid (pid_t pid, int *status_ptr, int options) {
     void* pre_call = ({
+        int status;
+        if (status_ptr == NULL) {
+            status_ptr = &status;
+        }
         struct Op op = {
             wait_op_code,
             {.wait = {
@@ -2018,6 +2022,10 @@ pid_t waitpid (pid_t pid, int *status_ptr, int options) {
 }
 pid_t wait (int *status_ptr) {
     void* pre_call = ({
+        int status;
+        if (status_ptr == NULL) {
+            status_ptr = &status;
+        }
         struct Op op = {
             wait_op_code,
             {.wait = {


### PR DESCRIPTION
According to [wait(2)](https://www.man7.org/linux/man-pages/man2/waitpid.2.html) the `int* wstatus` parameter in both `wait()` and `waitpid()` can be `NULL` (in which case the exit status is simply ignored), currently libprobe will segfault [here](https://github.com/charmoniumQ/PROBE/blob/a603dee0854f3b48bfab5a15d318dee482819c4a/probe_src/libprobe/generator/libc_hooks_source.c#L2040) when trying to dereference that pointer. This PR fixes the bug by substituting our own `int*` if it's not defined by the caller.