### PR TITLE
changed process graph to accomodate pthreads

### DIFF
--- a/probe_src/probe_py/parse_probe_log.py
+++ b/probe_src/probe_py/parse_probe_log.py
@@ -36,8 +36,10 @@ InitThreadOp: typing.TypeAlias = py_types[("struct", "InitThreadOp")]
 CloneOp: typing.TypeAlias = py_types[("struct", "CloneOp")]
 ExecOp: typing.TypeAlias = py_types[("struct", "ExecOp")]
 WaitOp: typing.TypeAlias = py_types[("struct", "WaitOp")]
+OpenOp: typing.TypeAlias = py_types[("struct", "OpenOp")]
+CloseOp: typing.TypeAlias = py_types[("struct", "CloseOp")]
 OpCode: enum.EnumType = py_types[("enum", "OpCode")]
-
+TaskType: enum.EnumType = py_types[("enum", "TaskType")]
 
 @dataclasses.dataclass
 class ThreadProvLog:


### PR DESCRIPTION
### Changes Made:
- For every `cloneOp` Op with the pthread_id same as `task_id` of `cloneOp` is found and an edge is created from `CloneOp` to the found `op`
-  For every `waitOp` last op with the pthread_id same as `ret` is found and an edge is created with the last `op` to `waitOp`