### PR TITLE
Fix `nix flake check --all-systems` on top-level flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,7 @@
     flake-utils.lib.eachDefaultSystem (
       system: let
         pkgs = nixpkgs.legacyPackages.${system};
+        inherit (pkgs) lib;
         python312-debug = pkgs.python312.overrideAttrs (oldAttrs: {
           configureFlags = oldAttrs.configureFlags ++ ["--with-pydebug"];
           # patches = oldAttrs.patches ++ [ ./python.patch ];
@@ -30,26 +31,39 @@
         };
         devShells = {
           default = pkgs.mkShell {
-            buildInputs = [
-              (pkgs.python312.withPackages (pypkgs: [
-                pypkgs.typer
-                pypkgs.pycparser
-                pypkgs.pytest
-                pypkgs.mypy
-                pypkgs.pygraphviz
-                pypkgs.networkx
-                pypkgs.ipython
-                pypkgs.pydot
-              ]))
-              # (export-and-rename python312-debug [["bin/python" "bin/python-dbg"]])
-              pkgs.gcc
-              pkgs.gdb
-              pkgs.coreutils
-              pkgs.bash
-              pkgs.xdot
-              pkgs.alejandra
-              pkgs.hyperfine
-            ];
+            buildInputs = 
+              [
+                (pkgs.python312.withPackages (pypkgs: [
+                  pypkgs.typer
+                  pypkgs.pycparser
+                  pypkgs.pytest
+                  pypkgs.mypy
+                  pypkgs.pygraphviz
+                  pypkgs.networkx
+                  pypkgs.ipython
+                  pypkgs.pydot
+                ]))
+                # (export-and-rename python312-debug [["bin/python" "bin/python-dbg"]])
+                pkgs.gcc
+                pkgs.gdb
+                pkgs.coreutils
+                pkgs.bash
+                pkgs.xdot
+                pkgs.alejandra
+                pkgs.hyperfine
+              ]
+              ++ (
+                # gdb broken on apple silicon
+                if system != "aarch64-darwin"
+                then [pkgs.gdb]
+                else []
+              )
+              ++ (
+                # while xdot isn't marked as linux only, it has a dependency (xvfb-run) that is
+                if builtins.elem system lib.platforms.linux
+                then [pkgs.xdot]
+                else []
+              );
           };
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -45,10 +45,8 @@
                 ]))
                 # (export-and-rename python312-debug [["bin/python" "bin/python-dbg"]])
                 pkgs.gcc
-                pkgs.gdb
                 pkgs.coreutils
                 pkgs.bash
-                pkgs.xdot
                 pkgs.alejandra
                 pkgs.hyperfine
               ]


### PR DESCRIPTION
Prior to this PR, both darwin platforms would fail when running checks, this fixes this by only adding certain packages to the shell if they're available on the given platform; I'm not sure whether this is truly the best approach, and I'm open to feedback if you don't like this approach.