### PR TITLE
frontend: pass unknown subcommands to python CLI

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,8 @@
                   makeWrapper \
                     ${self.packages.${system}.probe-cli}/bin/probe \
                     $out/bin/probe \
-                    --set __PROBE_LIB ${libprobe}/lib
+                    --set __PROBE_LIB ${libprobe}/lib \
+                    --prefix PATH : ${probe-py}/bin
                 '';
               };
             probe-py-manual = python.pkgs.buildPythonPackage rec {
@@ -96,6 +97,7 @@
               ];
               pythonImportsCheck = [pname];
             };
+            probe-py = python.withPackages (pypkgs: [probe-py-manual]);
             default = probe-bundled;
           }
           // frontend.packages;


### PR DESCRIPTION
Before this is merged the error handling semantics need to be improved a little bit, I'm open to suggestions as to the best way to do this, but some things that might help me would be, knowing:

- Is there any formalized spec for error codes emitted by the python CLI?
- Is there a good way to detect what subcommands are available in the python CLI instead of just catching the error if it's invalid?