### PR TITLE
Add failing tests

### DIFF
--- a/probe_src/libprobe/src/global_state.c
+++ b/probe_src/libprobe/src/global_state.c
@@ -212,6 +212,26 @@ static struct ArenaDir* get_data_arena() {
     return &__data_arena;
 }
 
+char* _DEFAULT_PATH = NULL;
+
+static void init_default_path() {
+    size_t default_path_size = EXPECT(!= 0, confstr(_CS_PATH, NULL, 0));
+    default_path_size += 1;
+    // Technically +1 is not necessary, but it wont' hurt
+
+    _DEFAULT_PATH = EXPECT_NONNULL(malloc(default_path_size));
+    EXPECT(!= 0, confstr(_CS_PATH, _DEFAULT_PATH, default_path_size));
+
+    // Technically, this shouldn't be necessary, but it won't hurt.
+    _DEFAULT_PATH[default_path_size] = '\0';
+}
+static char* get_default_path() {
+    assert(_DEFAULT_PATH != NULL);
+    return _DEFAULT_PATH;
+}
+
+/*******************************************************/
+
 /**
  * Aggregate functions;
  * These functions call the init_* functions above */
@@ -220,6 +240,7 @@ static void init_process_global_state() {
     init_exec_epoch();
     init_copy_files();
     init_probe_dir();
+    init_default_path();
 }
 
 static void init_thread_global_state() {

--- a/probe_src/libprobe/src/lookup_on_path.c
+++ b/probe_src/libprobe/src/lookup_on_path.c
@@ -1,43 +1,44 @@
 static bool lookup_on_path(BORROWED const char* bin_name, BORROWED char* bin_path) {
-    const char* path_segment_start = getenv("PATH");
-    DEBUG("looking up \"%s\" on $PATH=\"%.50s...\"", bin_name, path_segment_start);
     size_t bin_name_length = strlen(bin_name);
-    while (path_segment_start[0] == ':') {
-        /* TODO: Test case where PATH starts with : */
-        path_segment_start++;
-    }
-    bool has_elements = path_segment_start != NULL && path_segment_start[0] != '\0';
-    /* TODO: Use default PATH when PATH is unset */
-    if (has_elements) {
-        while (true) {
-            size_t path_segment_length = strcspn(path_segment_start, ":\0");
-            path_join(bin_path, path_segment_length, path_segment_start, bin_name_length, bin_name);
-            struct Op op = {
-                access_op_code,
-                {.access = {create_path_lazy(AT_FDCWD, bin_path, 0), 0, 0, 0}},
-                {0},
-                0,
-                0,
-            };
-            /* TODO: Test case where PATH element is relative */
-            prov_log_try(op);
-            int access_ret = unwrapped_faccessat(AT_FDCWD, bin_path, X_OK, 0);
-            if (access_ret == 0) {
-                prov_log_record(op);
-                return true;
-            } else {
-                op.data.access.ferrno = errno;
-                prov_log_record(op);
-            }
-            while (path_segment_start[0] != ':') {
-                /* TODO: Test case where PATH segment contains empty strings, /foo/bin:::/bar/bin */
-                path_segment_start++;
-            }
-            path_segment_start++;
-            if (path_segment_start[0] == '\0') {
-                break;
-            }
+    char* env_path = getenv("PATH");
+
+    /*
+     * If this variable isn't defined, the path list defaults
+     * to a list that includes the directories returned by
+     * confstr(_CS_PATH) (which typically returns the value
+     * "/bin:/usr/bin") and possibly also the current working directory;
+     * see VERSIONS for further details.
+     *
+     * -- https://man7.org/linux/man-pages/man3/exec.3.html
+    */
+    char* path = env_path ? env_path : get_default_path();
+
+    DEBUG("looking up \"%s\" on $PATH=\"%.50s...\"", bin_name, path);
+
+    char* saveptr = NULL;
+    const char *delim = ":";
+    char *path_seg;
+    path_seg = strtok_r(path, delim, &saveptr);
+    while (path_seg) {
+        path_join(bin_path, -1, path_seg, bin_name_length, bin_name);
+        struct Op op = {
+            access_op_code,
+            {.access = {create_path_lazy(AT_FDCWD, bin_path, 0), 0, 0, 0}},
+            {0},
+            0,
+            0,
+        };
+        prov_log_try(op);
+        int access_ret = unwrapped_faccessat(AT_FDCWD, bin_path, X_OK, 0);
+        if (access_ret == 0) {
+            prov_log_record(op);
+            return true;
+        } else {
+            op.data.access.ferrno = errno;
+            prov_log_record(op);
         }
+        path_seg = strtok_r(NULL, delim, &saveptr);
     }
+
     return false;
 }

--- a/probe_src/libprobe/src/prov_ops.c
+++ b/probe_src/libprobe/src/prov_ops.c
@@ -111,23 +111,6 @@ static int fopen_to_flags(BORROWED const char* fopentype) {
     }
 }
 
-/*
-static void free_op(struct Op op) {
-    switch (op.op_code) {
-        case open_op_code: free_path(op.data.open.path); break;
-        case init_process_op_code: FREE(op.data.init_process.program_name); break;
-        case exec_op_code: free_path(op.data.exec.path); break;
-        case access_op_code: free_path(op.data.access.path); break;
-        case stat_op_code: free_path(op.data.stat.path); break;
-        case read_link_op_code:
-            free_path(op.data.read_link.path);
-            FREE((char*) op.data.read_link.resolved);
-            break;
-        default:
-    }
-}
-*/
-
 static const struct Path* op_to_path(const struct Op* op) {
     switch (op->op_code) {
         case open_op_code: return &op->data.open.path;

--- a/probe_src/tests/test_path_stuff.py
+++ b/probe_src/tests/test_path_stuff.py
@@ -1,0 +1,29 @@
+import shutil
+import pytest
+import pathlib
+import shlex
+import subprocess
+
+
+# Mash keyboard sufficiently
+nonexistent_command = "eugrhuerhuliaflsd"
+
+
+def test_probe_nonexistent_command():
+    assert shutil.which(nonexistent_command) is None, "please choose a nonexistent_command"
+    proc = subprocess.run(
+        ["probe", "record", "-f", nonexistent_command],
+        capture_output=True,
+        check=False,
+    )
+    # Rust wrapper catches and warns us of segfaults.
+    assert b"SIGSEGV" not in proc.stderr
+
+
+def test_probe_empty_path():
+    proc = subprocess.run(
+        ["probe", "record", "-f", "env", "PATH=", nonexistent_command],
+        capture_output=True,
+        check=False,
+    )
+    assert b"SIGSEGV" not in proc.stderr


### PR DESCRIPTION
`probe record nonexistent_bin` would segfault due to a shoddy `$PATH` parsing. Using stdlib `strtok_r` is much better than parsing it myself.