### PR TITLE
Fix "env: cat command not found"

### DIFF
--- a/probe_src/libprobe/src/lookup_on_path.c
+++ b/probe_src/libprobe/src/lookup_on_path.c
@@ -12,6 +12,8 @@ static bool lookup_on_path(BORROWED const char* bin_name, BORROWED char* bin_pat
      * -- https://man7.org/linux/man-pages/man3/exec.3.html
     */
     char* path = env_path ? env_path : get_default_path();
+    /* Note that strtok_r is destructive, so we will have to copy this. */
+    path = strndup(path, sysconf(_SC_ARG_MAX));
 
     DEBUG("looking up \"%s\" on $PATH=\"%.50s...\"", bin_name, path);
 


### PR DESCRIPTION
#76 introduced a regression that was somehow not caught in our tests.

```
probe record -f cat flake.nix
env: 'cat' command not found
```

This is because `strtok_r` is _destructive_, inserting `\0` in the string, which makes other users of `$PATH` think it is too short.

This patch fixes the issue by copying `$PATH` before calling `strtok_r`.