### PR TITLE
feat: versions of filenode to make df readable

### DIFF
--- a/probe_py/probe_py/analysis.py
+++ b/probe_py/probe_py/analysis.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass
 import pathlib
 import os
 import collections
-from dataclasses import field, dataclass
 
 class EdgeLabels(IntEnum):
     PROGRAM_ORDER = 1

--- a/probe_py/probe_py/analysis.py
+++ b/probe_py/probe_py/analysis.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 import pathlib
 import os
 import collections
+from dataclasses import field, dataclass
 
 class EdgeLabels(IntEnum):
     PROGRAM_ORDER = 1
@@ -37,14 +38,22 @@ class InodeOnDevice:
         return hash((self.device_major, self.device_minor, self.inode))
 
 @dataclass(frozen=True)
+class FileVersion:
+    mtime_sec: int
+    mtime_nsec: int
+
+@dataclass(frozen=False)
 class FileNode:
     inodeOnDevice: InodeOnDevice
-    version: tuple[int, int]
+    version: FileVersion
     file: str
 
     @property
     def label(self) -> str:
-        return f"{self.file} version(inode {self.version[0]} mtime {self.version[1]})"
+        return f"{self.file} inode {self.inodeOnDevice.inode}"
+
+    def __hash__(self):
+        return hash((self.inodeOnDevice.inode, self.inodeOnDevice.device_major, self.inodeOnDevice.device_minor))
 
 # type alias for a node
 Node: typing.TypeAlias = tuple[int, int, int, int]
@@ -250,7 +259,7 @@ def provlog_to_digraph(process_tree_prov_log: ProvLog) -> nx.DiGraph:
     add_edges(fork_join_edges, EdgeLabels.FORK_JOIN)
     return process_graph
 
-def traverse_hb_for_dfgraph(process_tree_prov_log: ProvLog, starting_node: Node, traversed: set[int] , dataflow_graph:nx.DiGraph, cmd_map: dict[int, list[str]]) -> None:
+def traverse_hb_for_dfgraph(process_tree_prov_log: ProvLog, starting_node: Node, traversed: set[int] , dataflow_graph:nx.DiGraph, cmd_map: dict[int, list[str]], inode_version_map: dict[int, set[FileVersion]]) -> None:
     starting_pid = starting_node[0]
     
     starting_op = prov_log_get_node(process_tree_prov_log, starting_node[0], starting_node[1], starting_node[2], starting_node[3])
@@ -277,7 +286,9 @@ def traverse_hb_for_dfgraph(process_tree_prov_log: ProvLog, starting_node: Node,
             dataflow_graph.add_node(processNode, label=processNode.cmd)
             file = InodeOnDevice(op.path.device_major, op.path.device_minor, op.path.inode)
             path_str = op.path.path.decode("utf-8")
-            curr_version = (op.path.inode, op.path.mtime.sec)
+            curr_version = FileVersion(op.path.mtime.sec, op.path.mtime.nsec)
+            inode_version_map.setdefault(op.path.inode, set())
+            inode_version_map[op.path.inode].add(curr_version)
             fileNode = FileNode(file, curr_version, path_str)
             dataflow_graph.add_node(fileNode, label=fileNode.label)
             path = pathlib.Path(op.path.path.decode("utf-8"))
@@ -310,7 +321,7 @@ def traverse_hb_for_dfgraph(process_tree_prov_log: ProvLog, starting_node: Node,
             target_nodes[op.task_id] = list()
         elif isinstance(op, WaitOp) and op.options == 0:
             for node in target_nodes[op.task_id]:
-                traverse_hb_for_dfgraph(process_tree_prov_log, node, traversed, dataflow_graph, cmd_map)
+                traverse_hb_for_dfgraph(process_tree_prov_log, node, traversed, dataflow_graph, cmd_map, inode_version_map)
                 traversed.add(node[2])
         # return back to the WaitOp of the parent process
         if isinstance(next_op, WaitOp):
@@ -329,7 +340,23 @@ def provlog_to_dataflow_graph(process_tree_prov_log: ProvLog) -> nx.DiGraph:
         if isinstance(op, ExecOp):
             if pid == tid and exec_epoch_no == 0:
                 cmd_map[tid] = [arg.decode(errors="surrogate") for arg in op.argv]
-    traverse_hb_for_dfgraph(process_tree_prov_log, root_node, traversed, dataflow_graph, cmd_map)
+
+    inode_version_map: dict[int, set[FileVersion]] = {}
+    traverse_hb_for_dfgraph(process_tree_prov_log, root_node, traversed, dataflow_graph, cmd_map, inode_version_map)
+
+    file_version: dict[str, int] = {}
+    for inode, versions in inode_version_map.items():
+        sorted_versions = sorted(versions, key=lambda version: (version.mtime_sec, version.mtime_nsec))
+        for idx, version in enumerate(sorted_versions):
+            str_id = f"{inode}_{version.mtime_sec}_{version.mtime_nsec}"
+            file_version[str_id] = idx
+
+    for idx, node in enumerate(dataflow_graph.nodes()):
+        if isinstance(node, FileNode):
+            str_id = f"{node.inodeOnDevice.inode}_{node.version.mtime_sec}_{node.version.mtime_nsec}"
+            label = f"{node.file} inode {node.inodeOnDevice.inode} fv {file_version[str_id]} "
+            nx.set_node_attributes(dataflow_graph, {node: label}, "label")
+
     return dataflow_graph
 
 def prov_log_get_node(prov_log: ProvLog, pid: int, exec_epoch: int, tid: int, op_no: int) -> Op:

--- a/probe_py/probe_py/analysis.py
+++ b/probe_py/probe_py/analysis.py
@@ -42,7 +42,7 @@ class FileVersion:
     mtime_sec: int
     mtime_nsec: int
 
-@dataclass(frozen=False)
+@dataclass(frozen=True)
 class FileNode:
     inodeOnDevice: InodeOnDevice
     version: FileVersion
@@ -51,9 +51,6 @@ class FileNode:
     @property
     def label(self) -> str:
         return f"{self.file} inode {self.inodeOnDevice.inode}"
-
-    def __hash__(self):
-        return hash((self.inodeOnDevice.inode, self.inodeOnDevice.device_major, self.inodeOnDevice.device_minor))
 
 # type alias for a node
 Node: typing.TypeAlias = tuple[int, int, int, int]

--- a/probe_py/tests/test_workflow.py
+++ b/probe_py/tests/test_workflow.py
@@ -2,7 +2,7 @@ import re
 import pytest
 import pathlib
 import networkx as nx  # type: ignore
-from probe_py.analysis import FileNode, ProcessNode, InodeOnDevice
+from probe_py.analysis import FileNode, ProcessNode, InodeOnDevice, FileVersion
 from probe_py.workflows import NextflowGenerator
 
 
@@ -18,8 +18,9 @@ def test_dataflow_graph_to_nextflow_script() -> None:
     b_file_path.write_text("This is A.txt")
 
     dataflow_graph = nx.DiGraph()
-    A = FileNode(InodeOnDevice(0,0,0), (0, 0), "A.txt")
-    B = FileNode(InodeOnDevice(0,0,1), (0, 0), "B.txt")
+
+    A = FileNode(InodeOnDevice(0,0,0), FileVersion(0, 0), "A.txt")
+    B = FileNode(InodeOnDevice(0,0,1), FileVersion(0, 0), "B.txt")
     W = ProcessNode(0, ("cp", "A.txt", "B.txt"))
     dataflow_graph.add_nodes_from([A, B], color="red")
     dataflow_graph.add_nodes_from([W], color="blue")
@@ -57,10 +58,10 @@ workflow {
     expected_script = re.sub(r'process_\d+', 'process_*', expected_script)
     assert script == expected_script
 
-    A = FileNode(InodeOnDevice(0,0,0), (0, 0), "A.txt")
-    B0 = FileNode(InodeOnDevice(0,0,1), (0, 0), "B.txt")
-    B1 = FileNode(InodeOnDevice(0,0,1), (1, 0), "B.txt")
-    C = FileNode(InodeOnDevice(0,0,3), (0, 0), "C.txt")
+    A = FileNode(InodeOnDevice(0,0,0), FileVersion(0, 0), "A.txt")
+    B0 = FileNode(InodeOnDevice(0,0,1), FileVersion(0, 0), "B.txt")
+    B1 = FileNode(InodeOnDevice(0,0,1), FileVersion(1, 0), "B.txt")
+    C = FileNode(InodeOnDevice(0,0,3), FileVersion(0, 0), "C.txt")
     W = ProcessNode(0,("cp", "A.txt", "B.txt"))
     X = ProcessNode(1,("sed", "s/foo/bar/g", "-i", "B.txt"))
     # Note, the filename in FileNode will not always appear in the cmd of ProcessNode!


### PR DESCRIPTION
- Added versions to the file node using the mtime to make the dataflow graph readable. Example df graph for ` probe record bash -c "cat flake.nix > test0 ; head test0 > test0"` 
![image](https://github.com/user-attachments/assets/bc4a1d36-1066-4b33-b9dd-8377a601bc11)

