### PR TITLE
fix: sanitize command to avoid pydot errors

### DIFF
--- a/probe_py/probe_py/analysis.py
+++ b/probe_py/probe_py/analysis.py
@@ -1,5 +1,6 @@
 import typing
 import networkx as nx  # type: ignore
+import ast
 from .ptypes import TaskType, ProvLog
 from .ops import Op, CloneOp, ExecOp, WaitOp, OpenOp, CloseOp, InitProcessOp, InitExecEpochOp, InitThreadOp, StatOp
 from .graph_utils import list_edges_from_start_node
@@ -20,7 +21,7 @@ class EdgeLabels(IntEnum):
 @dataclass(frozen=True)
 class ProcessNode:
     pid: int
-    cmd: tuple[str,...]
+    cmd: tuple[str,...] | str
     
 @dataclass(frozen=True)
 class InodeOnDevice:
@@ -257,7 +258,7 @@ def provlog_to_digraph(process_tree_prov_log: ProvLog) -> nx.DiGraph:
     return process_graph
 
 
-def sanitize_cmd(cmd: str) -> str:
+def sanitize_cmd(cmd: str | list[str]) -> str:
     """Sanitize the command string to remove characters that are not allowed in pydot graphviz."""
     try:
     


### PR DESCRIPTION
## Why?
The `networkx.drawing.nx_pydot.to_pydot` function does not allow colons in graph labels. Since the `cmd` label may contain a colon, I created a sanitize command function to prevent any errors.
## What?
The `sanitize_cmd` function takes a command list, removes colons, and returns a list of sanitized command strings.