### PR TITLE
Don't use vararg forwarding

### DIFF
--- a/libprobe/src/lib.c
+++ b/libprobe/src/lib.c
@@ -28,16 +28,6 @@
 #include <pthread.h>
 
 /*
- * pycparser cannot parse type-names as function-arguments (as in `va_arg(var_name, type_name)`)
- * so we use some macros instead.
- * To pycparser, these macros are defined as variable names (parsable as arguments).
- * To GCC these macros are defined as type names.
- * */
-#define __type_mode_t mode_t
-#define __type_charp char*
-#define __type_charpp char**
-
-/*
  * Likewise, ther is some bug with pycparser unable to parse inline funciton pointers.
  * So we will use a typedef alias.
  * */

--- a/libprobe/src/util.c
+++ b/libprobe/src/util.c
@@ -219,17 +219,6 @@ static OWNED const char* dirfd_path(int dirfd) {
     return ret;
 }
 
-/*
- * dirfd(3) is not tolerant of NULL:
- * header: https://github.com/bminor/glibc/blob/9fc639f654dc004736836613be703e6bed0c36a8/dirent/dirent.h#L226
- * src: https://github.com/bminor/glibc/blob/9fc639f654dc004736836613be703e6bed0c36a8/sysdeps/unix/sysv/linux/dirfd.c#L27
- *
- * -1 is never a valid fd because it's the error value for syscalls that return fds, so we can do the same.
- */
-static int try_dirfd(BORROWED DIR* dirp) {
-    return dirp ? (dirfd(dirp)) : (-1);
-}
-
 #ifndef NDEBUG
 static int fd_is_valid(int fd) {
     return unwrapped_fcntl(fd, F_GETFD) != -1 || errno != EBADF;


### PR DESCRIPTION
The old code used the GCC builtin `__builtin_apply` to forward variadic arguments to variadic functions. That is some dark GCC magic with no Clang (or Rust or Zig) equivalent. This PR refactors libc hooks to avoid forwarding variadic arguments in two ways: if we can call a non-variadic function, we do (`execl` calls `unwrapped_execv`); if we can enumerate the possible arguments, we do (`fcntl` and `open` use if-statements to call the "correct" `unwrapped_fcntl` and `unwrapped_open`).