### PR TITLE
Improve checks for compiled code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,5 +49,13 @@ jobs:
 
     # The devshell uses slightly different build process than the Nix pkg
     # Might as well test that too
-    - name: Build and test in devshell
-      run: nix develop --command just compile fix check test-native
+    #
+    # - name: Build and test in devshell
+    #   run: nix develop --command just lint compile test
+    #
+    # ^ That takes a long time, and it runs the same checks as nix flake check.
+    # Developers should run `just lint compile test` on their machines.
+    # CI and consumers will run `nix flake check`
+    # However, we still want to build the devshell so the build artifacts get uploaded to Cachix.
+    - name: Build devshell
+      run: nix develop --command true

--- a/Justfile
+++ b/Justfile
@@ -1,36 +1,29 @@
-fix-nix:
+lint-nix:
     alejandra .
 
 test-nix:
     nix build .#probe-bundled
-    nix flake check --all-systems
+    nix flake lint --all-systems
 
-fix-py: compile-cli
+lint-py: compile-cli
     # fix-py depends on compile-cli for the autogen python code
     #ruff format probe_py/ tests/ libprobe/generator/ # TODO: uncomment
     ruff check --fix probe_py/ tests/ libprobe/generator/
-
-check-py: compile-cli
     # dmypy == daemon mypy; much faster on subsequent iterations.
     dmypy run -- --strict --no-namespace-packages --pretty probe_py/ tests/ libprobe/generator/
 
 [working-directory: 'cli-wrapper']
-fix-cli:
+lint-cli:
     # cargo clippy refuses to run if unstaged inputs (fixes may be destructive)
     # so we git add -A
     git add -A
     cargo clippy --fix --allow-staged -- --deny warnings
     cargo fmt
-
-[working-directory: 'cli-wrapper']
-check-cli:
-    cargo fmt --check
     cargo doc --workspace
-    cargo clippy -- --deny warnings
     cargo deny check
     cargo audit
-    cargo hakari generate --diff
-    cargo hakari manage-deps --dry-run
+    cargo hakari generate
+    cargo hakari manage-deps
 
 [working-directory: 'cli-wrapper']
 compile-cli:
@@ -38,33 +31,23 @@ compile-cli:
     cargo build --release
 
 [working-directory: 'libprobe']
-fix-lib:
-	make format
+lint-lib:
+    make format
+    make check
 
 [working-directory: 'libprobe']
 compile-lib:
     make all
 
-[working-directory: 'libprobe']
-check-lib:
-    make check
-
 [working-directory: 'tests/examples']
 compile-tests:
     make all
 
-fix: fix-nix fix-py fix-cli fix-lib
-
-check: check-py check-cli check-lib
+lint: lint-py lint-cli lint-lib
 
 compile: compile-cli compile-lib compile-tests
 
-test-native: compile
+test: compile
     python -m pytest tests/ -ra --failed-first --maxfail=1 -v
 
-test: test-native
-# Unless you the user explicitly asks (`just test-nix`),
-# we don't really need to test-nix.
-# It runs the same checks as `just test` and `just check`, but in Nix.
-
-pre-commit: fix check compile test
+pre-commit: lint compile test

--- a/Justfile
+++ b/Justfile
@@ -24,9 +24,13 @@ fix-cli:
 
 [working-directory: 'cli-wrapper']
 check-cli:
-    cargo clippy -- --deny warnings
-    cargo doc --workspace
     cargo fmt --check
+    cargo doc --workspace
+    cargo clippy -- --deny warnings
+    cargo deny check
+    cargo audit
+    cargo hakari generate --diff
+    cargo hakari manage-deps --dry-run
 
 [working-directory: 'cli-wrapper']
 compile-cli:

--- a/cli-wrapper/Cargo.lock
+++ b/cli-wrapper/Cargo.lock
@@ -792,6 +792,7 @@ dependencies = [
  "fs_extra",
  "libc",
  "log",
+ "my-workspace-hack",
  "probe_headers",
  "probe_lib",
  "tar",
@@ -804,6 +805,7 @@ version = "0.2.0"
 dependencies = [
  "cbindgen",
  "clap",
+ "my-workspace-hack",
 ]
 
 [[package]]
@@ -814,6 +816,7 @@ dependencies = [
  "libc",
  "log",
  "machine-info",
+ "my-workspace-hack",
  "probe_headers",
  "probe_macros",
  "rayon",
@@ -826,6 +829,7 @@ dependencies = [
 name = "probe_macros"
 version = "0.2.0"
 dependencies = [
+ "my-workspace-hack",
  "parking_lot",
  "proc-macro2",
  "quote",

--- a/cli-wrapper/cli/Cargo.toml
+++ b/cli-wrapper/cli/Cargo.toml
@@ -23,6 +23,7 @@ probe_headers = { path = "../headers" }
 tar = "0.4.41"
 tempfile = "3.19.1"
 fs_extra = "1.3.0"
+my-workspace-hack = { version = "0.1", path = "../my-workspace-hack" }
 
 [lints]
 workspace = true

--- a/cli-wrapper/headers/Cargo.toml
+++ b/cli-wrapper/headers/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 
 [dependencies]
 clap = {version = "4.5.35", features = ["derive"]}
+my-workspace-hack = { version = "0.1", path = "../my-workspace-hack" }
 
 [build-dependencies]
 cbindgen = "0.28.0"

--- a/cli-wrapper/headers/build.rs
+++ b/cli-wrapper/headers/build.rs
@@ -13,8 +13,8 @@ fn main() {
         )
         .with_after_include(
             "
-#include <stdint.h>
-#include <stdbool.h>
+#include <stdint.h>  // for uint32_t
+#include <stdbool.h> // for bool
 
 #define LD_PRELOAD_VAR \"LD_PRELOAD\"
 #define PROBE_DIR_VAR \"PROBE_DIR\"

--- a/cli-wrapper/lib/Cargo.toml
+++ b/cli-wrapper/lib/Cargo.toml
@@ -23,6 +23,7 @@ rayon = "1.10.0"
 serde = { version = "1.0.203", features = ["serde_derive"] }
 serde_json = "1.0.118"
 thiserror = "1.0.61"
+my-workspace-hack = { version = "0.1", path = "../my-workspace-hack" }
 
 [build-dependencies]
 bindgen = "0.69.4"

--- a/cli-wrapper/macros/Cargo.toml
+++ b/cli-wrapper/macros/Cargo.toml
@@ -15,6 +15,7 @@ parking_lot = "0.12.3"
 proc-macro2 = "1.0.86"
 quote = "1.0.36"
 syn = "2.0.68"
+my-workspace-hack = { version = "0.1", path = "../my-workspace-hack" }
 
 [lints]
 workspace = true

--- a/flake.nix
+++ b/flake.nix
@@ -219,6 +219,12 @@
             ];
             packages =
               [
+                # Rust stuff
+                pkgs.cargo-deny
+                pkgs.cargo-audit
+                pkgs.cargo-machete
+                pkgs.cargo-hakari
+
                 (python.withPackages (pypkgs: [
                   # probe_py.manual runtime requirements
                   pypkgs.networkx
@@ -252,11 +258,11 @@
                 pkgs.clang-analyzer
                 pkgs.clang-tools # must go after clang-analyzer
                 pkgs.clang # must go after clang-tools
-                pkgs.compiledb
                 pkgs.cppcheck
-                pkgs.cppclean
                 pkgs.gnumake
                 pkgs.git
+                pkgs.include-what-you-use
+                pkgs.libclang
                 # pkgs.musl
 
                 pkgs.which

--- a/flake.nix
+++ b/flake.nix
@@ -76,9 +76,14 @@
             version = "0.1.0";
             src = ./libprobe;
             makeFlags = ["INSTALL_PREFIX=$(out)" "SOURCE_VERSION=${version}"];
+            doCheck = true;
+            checkInputs = [
+                pkgs.clang-tools
+                pkgs.cppcheck
+                pkgs.include-what-you-use
+            ];
             buildInputs = [
               pkgs.git
-              pkgs.compiledb
               (python.withPackages (pypkgs: [
                 pypkgs.pycparser
               ]))

--- a/flake.nix
+++ b/flake.nix
@@ -78,9 +78,9 @@
             makeFlags = ["INSTALL_PREFIX=$(out)" "SOURCE_VERSION=${version}"];
             doCheck = true;
             checkInputs = [
-                pkgs.clang-tools
-                pkgs.cppcheck
-                pkgs.include-what-you-use
+              pkgs.clang-tools
+              pkgs.cppcheck
+              pkgs.include-what-you-use
             ];
             buildInputs = [
               pkgs.git

--- a/libprobe/Makefile
+++ b/libprobe/Makefile
@@ -8,6 +8,9 @@ CFLAGS := \
     -Wall -Wextra \
     -Wno-unused-command-line-argument \
     -fstrict-aliasing
+# musl-clang wrapper triggers -Wno-unused-command-line-argument.
+# But musl with clang (normal invocation) does not.
+
 DBGCFLAGS := -Og -g       -fpic
 OPTCFLAGS := -O3 -DNDEBUG -fPIC
 GENERATED_SOURCE_FILES := generated/libc_hooks.c
@@ -26,42 +29,47 @@ generated: $(GENERATED_FILES)
 .PHONY: generated
 
 $(BUILD_DIR)/libprobe.so: $(addprefix $(BUILD_DIR)/,$(SOURCE_FILES:.c=.o)) $(MAKEFILE_LIST)
-	$(CC) -flto    -fpic -shared -o $@ $(addprefix $(BUILD_DIR)/,$(SOURCE_FILES:.c=.o))
+	$(CC) -MJ $@.compile_command.json -flto    -fpic -shared -o $@ $(addprefix $(BUILD_DIR)/,$(SOURCE_FILES:.c=.o))
 
 $(BUILD_DIR)/libprobe.dbg.so: $(addprefix $(BUILD_DIR)/,$(SOURCE_FILES:.c=.dbg.o)) $(MAKEFILE_LIST)
-	$(CC) -fno-lto -fPIC -shared -o $@ $(addprefix $(BUILD_DIR)/,$(SOURCE_FILES:.c=.dbg.o))
+	$(CC) -MJ $@.compile_command.json -fno-lto -fPIC -shared -o $@ $(addprefix $(BUILD_DIR)/,$(SOURCE_FILES:.c=.dbg.o))
 
 $(BUILD_DIR)/%.o: %.c $(HEADER_FILES) $(MAKEFILE_LIST)
 	mkdir --parents $(dir $@)
-	$(CC) -c $(CFLAGS) $(OPTCFLAGS) -o $@ $<
+	$(CC) -MJ $@.compile_command.json -c $(CFLAGS) $(OPTCFLAGS) -o $@ $<
 
 $(BUILD_DIR)/%.dbg.o: %.c $(HEADER_FILES) $(MAKEFILE_LIST)
 	mkdir --parents $(dir $@)
-	$(CC) -c $(CFLAGS) $(DBGCFLAGS) -o $@ $<
+	$(CC) -MJ $@.compile_command.json -c $(CFLAGS) $(DBGCFLAGS) -o $@ $<
 
 $(GENERATED_FILES): $(wildcard generator/*) $(MAKEFILE_LIST)
 	mkdir --parents generated/
 	python3 ./generator/gen_libc_hooks.py
 
-compile_commands.json: $(MAKEFILE_LIST)
-	$(MAKE) clean
-	$(MAKE) $(BUILD_DIR)/libprobe.dbg.so --dry-run | compiledb
-# compiledb is better than bear.
-# For bear, you have to actually run the compile.
-# For compiledb, you can just dry-run.
-
-$(BUILD_DIR)/defined_symbols.txt: $(BUILD_DIR)/libprobe.dbg.so
-	nm --dynamic .build/libprobe.dbg.so | grep ' U ' | sed 's/  */ /g' | cut --delim=' ' --fields=3 > $(BUILD_DIR)/undefined_symbols.txt
+compile_commands.json: $(BUILD_DIR)/libprobe.dbg.so
+	echo '[' > $@
+	env --chdir=$(BUILD_DIR) find . -name '*.compile_command.json' -exec cat '{}' \; >> $@
+	echo ']' >> $@
 
 $(BUILD_DIR)/undefined_symbols.txt: $(BUILD_DIR)/libprobe.dbg.so
+	nm --dynamic .build/libprobe.dbg.so | grep ' U ' | sed 's/  */ /g' | cut --delim=' ' --fields=3 > $(BUILD_DIR)/undefined_symbols.txt
+
+$(BUILD_DIR)/defined_symbols.txt: $(BUILD_DIR)/libprobe.dbg.so
 	nm --dynamic .build/libprobe.dbg.so | grep ' T ' | cut --fields=3 --delimiter=' ' > $(BUILD_DIR)/defined_symbols.txt
 
 check: compile_commands.json $(GENERATED_FILES)
+	clang-check --analyze -extra-arg -Xanalyzer -extra-arg -analyzer-output=text $(SOURCE_FILES)
 	clang-format --dry-run --Werror $(MANUAL_SOURCE_FILES) $(MANUAL_HEADER_FILES)
-	clang-check $(SOURCE_FILES)
+	echo $(SOURCE_FILES) $(HEADER_FILES) | xargs --max-args 1 include-what-you-use -Xiwyu --error=1
 	clang-tidy  $(SOURCE_FILES)
 	cppcheck    $(SOURCE_FILES) --check-level=exhaustive -UNDEBUG
-#	cppclean    $(SOURCE_FILES) # see libprobe/README.md
+
+#	cppclean    $(SOURCE_FILES)
+# Currently, cppclean does not provide a mechanism to disable warnings.
+# It flags *all* static data as a warning because it may not be threadsafe.
+# I have carefully ensured our static data is either thread-local or guarded by a mutex (at initialization time)
+# Nevertheless, selecting which warnings to flag is still a TODO in cppclean.
+# https://github.com/myint/cppclean/blob/aa73d06022533a3ff0a956910f2df9a54c233d88/cpp/find_warnings.py#L18
 .PHONY: check
 
 deep-check:

--- a/libprobe/README.md
+++ b/libprobe/README.md
@@ -5,7 +5,7 @@ Required reading: <https://matt.sh/howto-c>
 # Refresh the compile_commands.json
 
 ``` sh
-make clean && bear -- make
+make clean && make compile_commands.json
 ```
 
 # C source checks
@@ -28,29 +28,20 @@ make clean && bear -- make
 
 - Ensure `nonnull` and `returns_nonnull` are applied where applicable.
 
-# cppclean
-
-Output of cppclean seems wrong
-For example,
-
-    src/prov_buffer.h:3: '../include/libprobe/prov_ops.h' does not need to be #included
-
-Howver, we can't foward-declare it because a public function takes a struct Op (by value).
-Therefore, we need the struct layout in the header.
-
-# C lints
-
-- https://github.com/include-what-you-use/include-what-you-use
-- https://code.google.com/archive/p/cppclean
+# Run C lints
 
 ``` sh
-clang-check include/libprobe/* src/* generated/*
+make format
 
-make clean && scan-build make
+make check
+
+make deep-check
 
 # https://github.com/NixOS/nixpkgs/pull/395967
 # https://clang.llvm.org/docs/analyzer/user-docs/CommandLineUsage.html#codechecker
 # https://github.com/Ericsson/codechecker/blob/master/docs/usage.md
+# TODO: make CodeChecker work
 CodeChecker analyze compile_commands.json -o reports
 ```
 
+Unfortunately [include-what-you-use](https://github.com/include-what-you-use/include-what-you-use), it often suggests "private/implementation-defined" headers like `linux/limits.h` rather than the [documented public interface `limits.h`](https://www.man7.org/linux/man-pages/man0/limits.h.0p.html). For those cases, I overrode those wrong cases with the comment; search `IWYU pragma` to see examples.

--- a/libprobe/README.md
+++ b/libprobe/README.md
@@ -12,11 +12,9 @@ make clean && bear -- make
 
 - Don't use `__` to mark private variables; it's ugly and they will have hidden visibility by default.
 
-- See if global variables can be converted to static function variables.
+- See if global variables can be converted to static function variables (same lifetime, but scoped to the function).
 
-- Include its own header last.
-
-- Don't duplicate includes already present in headers.
+- Include its own header first.
 
 - Apply `nonnull` attribute liberally.
 
@@ -27,6 +25,8 @@ make clean && bear -- make
 - Always begin with `#pragma once`.
 
 - All functions should be `__attribute__((visibility("hidden")))` if used elsewhere in the project or `__attribute__((visibility("default")))` if exported to public API.
+
+- Ensure `nonnull` and `returns_nonnull` are applied where applicable.
 
 # cppclean
 

--- a/libprobe/generator/gen_libc_hooks.py
+++ b/libprobe/generator/gen_libc_hooks.py
@@ -259,7 +259,7 @@ class ParsedFunc:
 
 
 filename = pathlib.Path("generator/libc_hooks_source.c")
-ast = pycparser.parse_file(filename, use_cpp=True)
+ast = pycparser.parse_file(filename, use_cpp=True, cpp_args=["-Wno-unused-command-line-argument"])
 orig_funcs = {
     node.decl.name: ParsedFunc.from_defn(node)
     for node in ast.ext

--- a/libprobe/generator/gen_libc_hooks.py
+++ b/libprobe/generator/gen_libc_hooks.py
@@ -468,32 +468,28 @@ includes = """
 
 #define _GNU_SOURCE
 
-/*
- * error: attribute declaration must precede definition [-Werror,-Wignored-attributes]
- *
- * Fix that by copying some of these before pesky includes
- */
-#include <sys/types.h>
-__attribute__((visibility("default"))) char * realpath(const char * restrict name, char * restrict resolved);
-__attribute__((visibility("default"))) ssize_t readlink(const char *filename, char *buffer, size_t size);
-__attribute__((visibility("default"))) ssize_t readlinkat(int dirfd, const char *filename, char *buffer, size_t size);
+#include <dirent.h>               // for DIR
+#include <features.h>             // for __USE_GNU
+#include <ftw.h>                  // for FTW
+#include <pthread.h>              // IWYU pragma: keep for pthread_t, pthread_attr_t
+#include <signal.h>               // for siginfo_t
+#include <stdio.h>                // for L_tmpnam, FILE, size_t
+#include <sys/stat.h>             // IWYU pragma: keep for stat
+#include <sys/time.h>             // IWYU pragma: keep for timeval
+#include <sys/types.h>            // for pid_t, mode_t, ssize_t, gid_t, uid_t
+#include <sys/wait.h>             // IWYU pragma: keep for idtype_t
+#include <threads.h>              // for thrd_t, thrd_start_t
+// IWYU pragma: no_include "bits/pthreadtypes.h" for pthread_t
+// IWYU pragma: no_include "bits/types/idtype_t.h" for idtype_t
+// IWYU pragma: no_include "bits/types/sigevent_t.h" for pthread_attr_t
 
-#include <stdio.h>
-#include <dirent.h>
-#include <ftw.h>
-#include <threads.h>
-#include <pthread.h>
-#include <utime.h>
-#include <fcntl.h>
-#include <sys/stat.h>
-#include <sys/wait.h>
-#include <sys/time.h>
-
-#include "../src/util.h"
-#include "../src/debug_logging.h"
+struct rusage;
+struct stat;
+struct statx;
+struct utimbuf;
 
 /*
- * There is some bug with pycparser unable to parse inline funciton pointers.
+ * There is some bug with pycparser unable to parse inline function pointers.
  * So we will use a typedef alias.
  */
 typedef int (*fn_ptr_int_void_ptr)(void*);
@@ -505,6 +501,10 @@ typedef int (*nftw_func)(const char *, const struct stat *, int, struct FTW *);
  * Best to feature test than test for compiler/libc, but sometimes feature testing is not possible in the preprocessor.
  */
 
+#ifndef __USE_GNU
+#define __MUSL__
+#endif
+
 // Musl defines tmpnam(char*)
 // Glibc defines tmpnam(char[L_tmpnam])
 // We use tmpnam(char[L_tmpnam]) and let this macro handle the difference
@@ -512,8 +512,6 @@ typedef int (*nftw_func)(const char *, const struct stat *, int, struct FTW *);
 #define __PROBE_L_tmpnam
 #elif __USE_GNU
 #define __PROBE_L_tmpnam L_tmpnam
-#else
-#error "Can't detect glibc nor musl; don't know how to define tmpnam(...)"
 #endif
 
 // On Glibc, struct dirent is 32-bit, with macros switch it to 64-bit or add new struct dirent64
@@ -537,18 +535,44 @@ defines = """
 #define _GNU_SOURCE
 
 #include "libc_hooks.h"
-#include <dlfcn.h>
-#include <limits.h>
-#include <limits.h>
-#include <stdarg.h>
 
-#include "../include/libprobe/prov_ops.h"
-#include "../src/prov_utils.h"
-#include "../src/prov_buffer.h"
-#include "../src/env.h"
-#include "../src/util.h"
-#include "../src/lookup_on_path.h"
-#include "../src/arena.h"
+#include <dirent.h>                                          // for DIR, dirfd
+#include <dlfcn.h>                                           // for dlsym
+#include <errno.h>                                           // for errno
+#include <fcntl.h>                                           // for AT_FDCWD, O_TMPFILE
+#include <ftw.h>                                             // for ftw, nftw
+#include <limits.h>                                          // for INT_MAX, PATH_MAX
+#include <pthread.h>                                         // for pthread_...
+#include <sched.h>                                           // for CLONE_TH...
+#include <stdarg.h>                                          // for va_arg
+#include <stdbool.h>                                         // for false, true
+#include <stdint.h>                                          // for int64_t
+#include <stdio.h>                                           // for fileno
+#include <stdlib.h>                                          // for free
+#include <string.h>                                          // for memcpy
+#include <sys/stat.h>                                        // for chmod, statx
+#include <sys/time.h>                                        // for futimes
+#include <sys/wait.h>                                        // for wait, wait3
+#include <threads.h>                                         // for thrd_t
+#include <unistd.h>                                          // for environ
+#include <utime.h>                                           // for utimbuf
+// IWYU pragma: no_include "bits/statx-generic.h"               for statx
+// IWYU pragma: no_include "bits/types/siginfo_t.h"             for si_pid, si_status
+// IWYU pragma: no_include "linux/limits.h"                     for PATH_MAX
+
+#include "../include/libprobe/prov_ops.h"                    // for Op, OpCode
+#include "../src/arena.h"                                    // for prov_log...
+#include "../src/env.h"                                      // for arena_co...
+#include "../src/lookup_on_path.h"                           // for lookup_o...
+#include "../src/prov_buffer.h"                              // for prov_log...
+#include "../src/prov_utils.h"                               // for create_p...
+#include "../src/util.h"                                     // for LIKELY
+#include "../src/debug_logging.h"                            // for DEBUG
+#include "../src/global_state.h"                             // for ensure_i...
+
+struct rusage;
+struct stat;
+struct statx;
 
 /*
  * pycparser cannot parse type-names as function-arguments (as in `va_arg(var_name, type_name)` or `sizeof(type_name)`)
@@ -575,7 +599,7 @@ typedef void* __type_voidp;
 
 // Clang and GCC disagree on how to construct this struct inline.
 // So I will construct it not inline, here.
-struct my_rusage null_usage = {0};
+const struct my_rusage null_usage = {0};
 """
 
 (generated / "libc_hooks.c").write_text(

--- a/libprobe/include/libprobe/prov_ops.h
+++ b/libprobe/include/libprobe/prov_ops.h
@@ -2,14 +2,17 @@
 
 #define _GNU_SOURCE
 
-#include <pthread.h>
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdint.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <threads.h>
-#include <utime.h>
+#include <pthread.h>   // IWYU pragma: keep for pthread_t
+#include <stdbool.h>   // for bool, false
+#include <stddef.h>    // for size_t, NULL
+#include <stdint.h>    // for uint32_t, int32_t, uint64_t, int64_t
+#include <sys/stat.h>  // IWYU pragma: keep for statx_timestamp
+#include <sys/time.h>  // for timeval
+#include <sys/types.h> // for pid_t, mode_t, gid_t, ino_t, uid_t
+#include <threads.h>   // for thrd_t
+#include <time.h>      // for timespec
+// IWYU pragma: no_include "bits/pthreadtypes.h" for pthread_t
+// IWYU pragma: no_include "linux/stat.h" for statx_timestamp
 
 // HACK: defining this manually instead of using <sys/resource.h> is
 // a huge hack, but it greatly reduces the generated code complexity

--- a/libprobe/src/arena.c
+++ b/libprobe/src/arena.c
@@ -1,21 +1,24 @@
 #define _GNU_SOURCE
 
-#include "../generated/libc_hooks.h"
-#include <fcntl.h>
-#include <stdalign.h>
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/mman.h>
-#include <unistd.h>
-
-#include "debug_logging.h"
-#include "util.h"
-
 #include "arena.h"
+
+#include <fcntl.h>    // for AT_FDCWD, O_CREAT, O_RDWR
+#include <stdbool.h>  // for bool, false, true
+#include <stddef.h>   // for size_t, NULL
+#include <stdint.h>   // for uintptr_t
+#include <stdio.h>    // for snprintf
+#include <stdlib.h>   // for free, malloc
+#include <string.h>   // for memcpy, strnlen
+#include <sys/mman.h> // for msync, munmap, MAP_FAILED, MS_SYNC, MAP_SHARED, PROT_READ
+#include <unistd.h>   // for getpagesize
+// IWYU pragma: no_include "bits/mman-linux.h"          for MS_SYNC, MAP_SHARED, PROT_READ
+
+#include "../generated/libc_hooks.h" // for unwrapped_close, unwrapped_ftru...
+#include "debug_logging.h"           // for EXPECT, ASSERTF, EXPECT_NONNULL
+#include "util.h"                    // for ceil_log2, MAX
+
+/* TODO: Interpose munmap. See global_state.c, ../generator/libc_hooks_source.c */
+#define unwrapped_munmap munmap
 
 struct Arena {
     size_t instantiation;
@@ -28,7 +31,6 @@ struct Arena {
  * The size of the array is ARENA_LIST_BLOCK_SIZE.
  * Making this larger requires more memory, but makes there be fewer linked-list allocations. */
 #define ARENA_LIST_BLOCK_SIZE 64
-struct ArenaListElem;
 struct ArenaListElem {
     struct Arena* arena_list[ARENA_LIST_BLOCK_SIZE];
     /* We store next list elem so that a value of 0 with an uninitialized arena_list represnts a valid ArenaListElem */

--- a/libprobe/src/arena.h
+++ b/libprobe/src/arena.h
@@ -2,10 +2,8 @@
 
 #define _GNU_SOURCE
 
-#include <stdbool.h>
-#include <stddef.h>
-
-struct ArenaListElem;
+#include <stdbool.h> // for bool
+#include <stddef.h>  // for size_t
 
 struct ArenaDir {
     int __dirfd;

--- a/libprobe/src/debug_logging.h
+++ b/libprobe/src/debug_logging.h
@@ -2,11 +2,11 @@
 
 #define _GNU_SOURCE
 
-#include "global_state.h" // used in macro for get_pid_safe()
-#include "util.h"
-#include <errno.h>
-#include <stdlib.h> // uesd in macro for exit()
-#include <string.h> // used in macro for strerror()
+#include "global_state.h" // for get_exec_epoch_safe, get_pid_safe, get_tid...
+#include <errno.h>        // for errno
+#include <stdio.h>        // for fprintf, stderr
+#include <stdlib.h>       // for exit, free
+#include <string.h>       // for strerror, strndup
 
 #ifndef NDEBUG
 #define DEBUG_LOG 1
@@ -39,7 +39,7 @@
 #ifndef NDEBUG
 #define ASSERTF(cond, str, ...)                                                                    \
     ({                                                                                             \
-        if (UNLIKELY(!(cond))) {                                                                   \
+        if (__builtin_expect(!(cond), 0)) {                                                        \
             ERROR("Assertion " #cond " failed: " str, ##__VA_ARGS__);                              \
         }                                                                                          \
     })
@@ -65,3 +65,10 @@
 #endif
 
 #define NOT_IMPLEMENTED(str, ...) ERROR("Not implemented: " str, ##__VA_ARGS__)
+
+__attribute__((unused)) static inline void __mark_as_used__debug_logging_h() {
+    fprintf(stderr, "hi");
+    strndup("hi", 3);
+    get_pid();
+    exit(1);
+}

--- a/libprobe/src/env.c
+++ b/libprobe/src/env.c
@@ -1,12 +1,16 @@
 #define _GNU_SOURCE
 
-#include <stdlib.h>
-#include <string.h>
+#include <limits.h>  // IWYU pragma: keep for PATH_MAX
+#include <stdbool.h> // for bool, false, true
+#include <stdlib.h>  // for malloc, getenv
+#include <string.h>  // for memcpy, memcmp, strlen, strnlen
+// IWYU pragma: no_include "linux/limits.h"  for PATH_MAX
 
-#include "../generated/bindings.h"
-#include "arena.h"
-#include "global_state.h"
-#include "util.h"
+#include "../generated/bindings.h" // for FixedPath, LD_PRELOAD_VAR, PROBE_...
+#include "arena.h"                 // for arena_calloc
+#include "debug_logging.h"         // for DEBUG, ASSERTF, EXPECT_NONNULL
+#include "global_state.h"          // for get_libprobe_path, get_probe_dir
+#include "util.h"                  // for UNSIGNED_INT_STRING_SIZE
 
 #include "env.h"
 

--- a/libprobe/src/env.h
+++ b/libprobe/src/env.h
@@ -2,7 +2,7 @@
 
 #define _GNU_SOURCE
 
-#include <stddef.h>
+#include <stddef.h> // for size_t
 struct ArenaDir;
 
 __attribute__((visibility("hidden"))) void printenv(void);

--- a/libprobe/src/global_state.c
+++ b/libprobe/src/global_state.c
@@ -1,27 +1,34 @@
 #define _GNU_SOURCE
 
-#include "../generated/libc_hooks.h"
-#include <errno.h>
-#include <limits.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
-
-#include "../generated/bindings.h"
-#include "arena.h"
-#include "env.h"
-#include "inode_table.h"
-#include "prov_buffer.h"
-#include "prov_utils.h"
-#include "util.h"
-
 #include "global_state.h"
+
+#include <errno.h>     // for errno
+#include <fcntl.h>     // for AT_FDCWD, O_CREAT, O_PATH, O_RD...
+#include <limits.h>    // IWYU pragma: keep for PATH_MAX
+#include <pthread.h>   // for pthread_mutex_t
+#include <stdbool.h>   // for true, bool, false
+#include <stdlib.h>    // for malloc, strtoul
+#include <string.h>    // for memcpy, NULL, size_t, strnlen
+#include <sys/stat.h>  // IWYU pragma: keep for STATX_BASIC_STATS, statx
+#include <sys/types.h> // for pid_t
+#include <unistd.h>    // for getpid, gettid, confstr, _CS_PATH
+// IWYU pragma: no_include "bits/pthreadtypes.h"  for pthread_mutex_t
+// IWYU pragma: no_include "linux/limits.h"       for PATH_MAX
+// IWYU pragma: no_include "linux/stat.h"         for STATX_BASIC_STATS, statx
+
+#include "../generated/bindings.h"   // for FixedPath, ProcessContext, PIDS...
+#include "../generated/libc_hooks.h" // for unwrapped_mkdirat, unwrapped_close
+#include "arena.h"                   // for arena_is_initialized, arena_create
+#include "debug_logging.h"           // for ASSERTF, EXPECT, DEBUG, ERROR
+#include "env.h"                     // for getenv_copy
+#include "inode_table.h"             // for inode_table_init, inode_table_i...
+#include "prov_utils.h"              // for do_init_ops
+#include "util.h"                    // for CHECK_SNPRINTF, list_dir, UNLIKELY
 
 #define PRIVATE_ENV_VAR_PREFIX "PROBE_"
 
 // getpid/gettid is kind of expensive (40ns per syscall)
 // but worth it for debug case
-
 static const pid_t pid_initial = -1;
 static pid_t pid = pid_initial;
 pid_t get_pid() { return EXPECT(== getpid(), pid); }

--- a/libprobe/src/global_state.h
+++ b/libprobe/src/global_state.h
@@ -2,10 +2,8 @@
 
 #define _GNU_SOURCE
 
-#include <stdbool.h>
-#include <unistd.h>
-
-struct ArenaDir;
+#include <stdbool.h>   // for bool
+#include <sys/types.h> // for pid_t
 
 /*
  * For each member of global state $X of type $T, we have

--- a/libprobe/src/inode_table.c
+++ b/libprobe/src/inode_table.c
@@ -1,13 +1,15 @@
 #define _GNU_SOURCE
 
-#include <pthread.h>
-#include <stddef.h>
-#include <stdlib.h>
-
-#include "../include/libprobe/prov_ops.h"
-#include "debug_logging.h"
-
 #include "inode_table.h"
+
+#include <pthread.h> // IWYU pragma: keep for pthread_rwlock_unlock, pthread_rwlock_t
+#include <stddef.h>  // for size_t, NULL
+#include <stdlib.h>  // for calloc
+// IWYU pragma: no_include "bits/pthreadtypes.h" for pthread_rwllock_t
+
+#include "../include/libprobe/prov_ops.h" // for Path
+#include "debug_logging.h"                // for ASSERTF, EXPECT, DEBUG
+#include "stdbool.h"                      // for false, bool, true
 
 /*
 ** Device major and minor are listed here:

--- a/libprobe/src/inode_table.h
+++ b/libprobe/src/inode_table.h
@@ -2,10 +2,9 @@
 
 #define _GNU_SOURCE
 
-#include <stdbool.h>
+#include <stdbool.h> // for bool
 
 struct Path;
-struct IndexTable;
 
 /*
  * This struct "hides" the implementation from users.

--- a/libprobe/src/lookup_on_path.c
+++ b/libprobe/src/lookup_on_path.c
@@ -1,14 +1,17 @@
 #define _GNU_SOURCE
 
-#include "../generated/libc_hooks.h"
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
-
-#include "util.h"
-
-#include "global_state.h"
 #include "lookup_on_path.h"
+
+#include <fcntl.h>   // for AT_FDCWD
+#include <stdbool.h> // for bool, false, true
+#include <stdlib.h>  // for getenv, size_t
+#include <string.h>  // for strlen
+#include <unistd.h>  // for X_OK
+
+#include "../generated/libc_hooks.h" // for unwrapped_faccessat
+#include "debug_logging.h"           // for DEBUG
+#include "global_state.h"            // for get_default_path
+#include "util.h"                    // for BORROWED, path_join
 
 bool lookup_on_path(BORROWED const char* bin_name, BORROWED char* bin_path) {
     size_t bin_name_length = strlen(bin_name);

--- a/libprobe/src/lookup_on_path.h
+++ b/libprobe/src/lookup_on_path.h
@@ -2,7 +2,8 @@
 
 #define _GNU_SOURCE
 
-#include "util.h"
+#include "util.h"    // for BORROWED
+#include <stdbool.h> // for bool
 
 __attribute__((visibility("hidden"))) bool lookup_on_path(BORROWED const char* bin_name,
                                                           BORROWED char* bin_path)

--- a/libprobe/src/prov_buffer.c
+++ b/libprobe/src/prov_buffer.c
@@ -1,18 +1,28 @@
 #define _GNU_SOURCE
 
-#include "../generated/libc_hooks.h"
-#include <fcntl.h>
-#include <limits.h>
-#include <string.h>
-
-#include "arena.h"
-#include "debug_logging.h"
-#include "global_state.h"
-#include "inode_table.h"
-#include "prov_utils.h"
-#include "util.h"
-
 #include "prov_buffer.h"
+
+#include <fcntl.h>   // for AT_FDCWD, O_RDWR, O_CREAT
+#include <limits.h>  // IWYU pragma: keep for PATH_MAX
+#include <pthread.h> // for pthread_self
+#include <sched.h>   // for CLONE_VFORK
+#include <stdbool.h> // for bool, true
+#include <stdio.h>   // for fprintf, stderr
+#include <string.h>  // for memcpy, size_t
+#include <threads.h> // for thrd_current
+#include <time.h>    // IWYU pragma: keep for timespec, clock_gettime
+#include <unistd.h>  // for F_OK
+// IWYU pragma: no_include "bits/time.h"    for CLOCK_MONOTONIC
+// IWYU pragma: no_include "linux/limits.h" for PATH_MAX
+
+#include "../generated/libc_hooks.h"      // for unwrapped_faccessat
+#include "../include/libprobe/prov_ops.h" // for Op, Path, OpCode, Op::(ano...
+#include "arena.h"                        // for arena_sync, arena_calloc
+#include "debug_logging.h"                // for DEBUG, ASSERTF, DEBUG_LOG
+#include "global_state.h"                 // for get_copied_or_overwritten_...
+#include "inode_table.h"                  // for inode_table_put_if_not_exists
+#include "prov_utils.h"                   // for op_to_human_readable, op_t...
+#include "util.h"                         // for copy_file
 
 void prov_log_save() {
     /* TODO: ensure we call Arena save in atexit, pthread_cleanup_push */

--- a/libprobe/src/prov_buffer.h
+++ b/libprobe/src/prov_buffer.h
@@ -1,6 +1,8 @@
 #define _GNU_SOURCE
 
-#include "../include/libprobe/prov_ops.h"
+#include <stdbool.h> // for bool
+
+struct Op;
 
 __attribute__((visibility("hidden"))) void prov_log_save();
 

--- a/libprobe/src/prov_utils.h
+++ b/libprobe/src/prov_utils.h
@@ -4,7 +4,7 @@
 
 #include "util.h"    // for BORROWED
 #include <stdbool.h> // for bool
-// IWYU pragma: no_include "../include/libprobe/prov_ops.h" for Op (ptr only), StatResult (ptr only)
+// IWYU pragma: no_include "libprobe/prov_ops.h" for Op (ptr only), StatResult (ptr only)
 // IWYU pragma: no_include "/build/libprobe/include/libprobe/prov_ops.h"
 
 struct Op;         // IWYU pragma: keep

--- a/libprobe/src/prov_utils.h
+++ b/libprobe/src/prov_utils.h
@@ -4,7 +4,8 @@
 
 #include "util.h"    // for BORROWED
 #include <stdbool.h> // for bool
-// IWYU pragma: no_include "libprobe/prov_ops.h" for Op (ptr only), StatResult (ptr only)
+// IWYU pragma: no_include "../include/libprobe/prov_ops.h" for Op (ptr only), StatResult (ptr only)
+// IWYU pragma: no_include "/build/libprobe/include/libprobe/prov_ops.h"
 
 struct Op;         // IWYU pragma: keep
 struct StatResult; // IWYU pragma: keep

--- a/libprobe/src/prov_utils.h
+++ b/libprobe/src/prov_utils.h
@@ -2,9 +2,16 @@
 
 #define _GNU_SOURCE
 
-#include "../include/libprobe/prov_ops.h"
-#include "util.h"
-#include <sys/resource.h>
+#include "util.h"    // for BORROWED
+#include <stdbool.h> // for bool
+// IWYU pragma: no_include "libprobe/prov_ops.h" for Op (ptr only), StatResult (ptr only)
+
+struct Op;         // IWYU pragma: keep
+struct StatResult; // IWYU pragma: keep
+struct my_rusage;  // IWYU pragma: keep
+struct rusage;
+struct stat;
+struct statx;
 
 __attribute__((visibility("hidden"))) struct Path
 create_path_lazy(int dirfd, BORROWED const char* path, int flags);

--- a/libprobe/src/util.h
+++ b/libprobe/src/util.h
@@ -3,15 +3,12 @@
 #define _GNU_SOURCE
 
 // https://stackoverflow.com/a/78062291/1078199
-#include <features.h>
-#ifndef __USE_GNU
-#define __MUSL__
-#endif
+#include <stdarg.h>    // for va_arg, va_end, va_start, va_list
+#include <stdbool.h>   // for bool
+#include <stdio.h>     // for snprintf, size_t
+#include <sys/types.h> // for ssize_t
 
-#include "debug_logging.h"
-#include <dirent.h>
-#include <stdbool.h>
-#include <stdio.h>
+#include "debug_logging.h" // for ASSERTF
 
 /*
  * OWNED/BORROWED determins who is responsible for freeing a pointer received or returned by a function-call.
@@ -86,3 +83,11 @@ __attribute__((visibility("hidden"))) void write_bytes(int dirfd, const char* pa
 
 __attribute__((visibility("hidden"))) unsigned char ceil_log2(unsigned int val)
     __attribute__((pure));
+
+__attribute__((unused)) static inline void __mark_as_used__util_h(int f, ...) {
+    char buf[10];
+    CHECK_SNPRINTF(buf, 10, "");
+    COUNT_NONNULL_VARARGS(f);
+    __attribute__((unused)) bool a = true;
+    __attribute__((unused)) size_t b = 1;
+}


### PR DESCRIPTION
- Add `include-what-you-use` for C; execute `just check-lib`. This removes extraneous includes and even suggests missing includes.

- Run `make check` in `nix flake check`. I made an oversight that `doChecks` is `false` by default, so the checks were not being run.

- Deduplicate checks we are running in CI.

- Run more Rust checks in `just check-cli`. These were already running in `nix flake check`, but this PR also runs them in the `Justfile` for rapid development.