### PR TITLE
Rename Python variables

### DIFF
--- a/probe_py/probe_py/analysis.py
+++ b/probe_py/probe_py/analysis.py
@@ -1,6 +1,6 @@
 import typing
 import networkx as nx  # type: ignore
-from .ptypes import TaskType, ProbeLog
+from .ptypes import TaskType, ProbeLog, Pid, ExecNo, Tid
 from .ops import Op, CloneOp, ExecOp, WaitOp, OpenOp, CloseOp, InitProcessOp, InitExecEpochOp, InitThreadOp, StatOp
 from .graph_utils import list_edges_from_start_node
 from collections import deque
@@ -360,8 +360,9 @@ def probe_log_to_dataflow_graph(probe_log: ProbeLog) -> DfGraph:
 
     return dataflow_graph
 
-def get_op(probe_log: ProbeLog, pid: int, exec_epoch: int, tid: int, op_no: int) -> Op:
-    return probe_log.processes[pid].execs[exec_epoch].threads[tid].ops[op_no]
+
+def get_op(probe_log: ProbeLog, pid: Pid, eno: ExecNo, tid: Tid, op_no: int) -> Op:
+    return probe_log.processes[pid].execs[eno].threads[tid].ops[op_no]
 
 
 def validate_hb_closes(probe_log: ProbeLog, hb_graph: HbGraph) -> list[str]:

--- a/probe_py/probe_py/analysis.py
+++ b/probe_py/probe_py/analysis.py
@@ -1,6 +1,6 @@
 import typing
 import networkx as nx  # type: ignore
-from .ptypes import TaskType, ProvLog
+from .ptypes import TaskType, ProbeLog
 from .ops import Op, CloneOp, ExecOp, WaitOp, OpenOp, CloseOp, InitProcessOp, InitExecEpochOp, InitThreadOp, StatOp
 from .graph_utils import list_edges_from_start_node
 from collections import deque
@@ -12,7 +12,8 @@ import pathlib
 import os
 import collections
 
-class EdgeLabels(IntEnum):
+
+class EdgeLabel(IntEnum):
     PROGRAM_ORDER = 1
     FORK_JOIN = 2
     EXEC = 3
@@ -58,21 +59,25 @@ Node: typing.TypeAlias = tuple[int, int, int, int]
 # type for the edges
 EdgeType: typing.TypeAlias = tuple[Node, Node]
 
-def validate_provlog(
-        provlog: ProvLog,
+
+HbGraph: typing.TypeAlias = nx.DiGraph
+DfGraph: typing.TypeAlias = nx.DiGraph
+
+def validate_probe_log(
+        probe_log: ProbeLog,
 ) -> list[str]:
     ret = list[str]()
     waited_processes = set[tuple[TaskType, int]]()
     cloned_processes = set[tuple[TaskType, int]]()
     opened_fds = set[int]()
     closed_fds = set[int]()
-    for pid, process in provlog.processes.items():
+    for pid, process in probe_log.processes.items():
         epochs = set[int]()
-        first_op = process.exec_epochs[0].threads[pid].ops[0]
+        first_op = process.execs[0].threads[pid].ops[0]
         if not isinstance(first_op.data, InitProcessOp):
             ret.append("First op in exec_epoch 0 should be InitProcessOp")
-        last_epoch = max(process.exec_epochs.keys())
-        for exec_epoch_no, exec_epoch in process.exec_epochs.items():
+        last_epoch = max(process.execs.keys())
+        for exec_epoch_no, exec_epoch in process.execs.items():
             epochs.add(exec_epoch_no)
             first_ee_op_idx = 1 if exec_epoch_no == 0 else 0
             first_ee_op = exec_epoch.threads[pid].ops[first_ee_op_idx]
@@ -120,7 +125,7 @@ def validate_provlog(
                     elif isinstance(op.data, CloneOp) and op.data.ferrno == 0:
                         if False:
                             pass
-                        elif op.data.task_type == TaskType.TASK_PID and op.data.task_id not in provlog.processes.keys():
+                        elif op.data.task_type == TaskType.TASK_PID and op.data.task_id not in probe_log.processes.keys():
                             ret.append(f"CloneOp returned a PID {op.data.task_id} that we didn't track")
                         elif op.data.task_type == TaskType.TASK_TID and op.data.task_id not in exec_epoch.threads.keys():
                             ret.append(f"CloneOp returned a TID {op.data.task_id} that we didn't track")
@@ -146,10 +151,7 @@ def validate_provlog(
     return ret
 
 
-# TODO: Rename "digraph" to "hb_graph" in the entire project.
-# Digraph (aka "directed graph") is too vague a term; the proper name is "happens-before graph".
-# Later on, we will have a function that transforms an hb graph to file graph (both of which are digraphs)
-def provlog_to_digraph(process_tree_prov_log: ProvLog) -> nx.DiGraph:
+def probe_log_to_hb_graph(probe_log: ProbeLog) -> HbGraph:
     # [pid, exec_epoch_no, tid, op_index]
     program_order_edges = list[tuple[Node, Node]]()
     fork_join_edges = list[tuple[Node, Node]]()
@@ -157,8 +159,8 @@ def provlog_to_digraph(process_tree_prov_log: ProvLog) -> nx.DiGraph:
     nodes = list[Node]()
     proc_to_ops = dict[tuple[int, int, int], list[Node]]()
     last_exec_epoch = dict[int, int]()
-    for pid, process in process_tree_prov_log.processes.items():
-        for exec_epoch_no, exec_epoch in process.exec_epochs.items():
+    for pid, process in probe_log.processes.items():
+        for exec_epoch_no, exec_epoch in process.execs.items():
             # to find the last executing epoch of the process
             last_exec_epoch[pid] = max(last_exec_epoch.get(pid, 0), exec_epoch_no)
             # Reduce each thread to the ops we actually care about
@@ -184,8 +186,8 @@ def provlog_to_digraph(process_tree_prov_log: ProvLog) -> nx.DiGraph:
 
     def get_first_pthread(pid: int, exid: int, target_pthread_id: int) -> list[Node]:
         ret = list[Node]()
-        for pid, process in process_tree_prov_log.processes.items():
-            for exid, exec_epoch in process.exec_epochs.items():
+        for pid, process in probe_log.processes.items():
+            for exid, exec_epoch in process.execs.items():
                 for tid, thread in exec_epoch.threads.items():
                     for op_index, op in enumerate(thread.ops):
                         if op.pthread_id == target_pthread_id:
@@ -195,8 +197,8 @@ def provlog_to_digraph(process_tree_prov_log: ProvLog) -> nx.DiGraph:
 
     def get_last_pthread(pid: int, exid: int, target_pthread_id: int) -> list[Node]:
         ret = list[Node]()
-        for pid, process in process_tree_prov_log.processes.items():
-            for exid, exec_epoch in process.exec_epochs.items():
+        for pid, process in probe_log.processes.items():
+            for exid, exec_epoch in process.execs.items():
                 for tid, thread in exec_epoch.threads.items():
                     for op_index, op in list(enumerate(thread.ops))[::-1]:
                         if op.pthread_id == target_pthread_id:
@@ -207,7 +209,7 @@ def provlog_to_digraph(process_tree_prov_log: ProvLog) -> nx.DiGraph:
     # Hook up forks/joins
     for node in list(nodes):
         pid, exid, tid, op_index = node
-        op_data = process_tree_prov_log.processes[pid].exec_epochs[exid].threads[tid].ops[op_index].data
+        op_data = probe_log.processes[pid].execs[exid].threads[tid].ops[op_index].data
         target: tuple[int, int, int]
         if False:
             pass
@@ -243,26 +245,26 @@ def provlog_to_digraph(process_tree_prov_log: ProvLog) -> nx.DiGraph:
             target = pid, exid + 1, pid
             exec_edges.append((node, first(*target)))
 
-    process_graph = nx.DiGraph()
+    hb_graph = HbGraph()
     for node in nodes:
-        process_graph.add_node(node)
+        hb_graph.add_node(node)
 
-    def add_edges(edges:list[tuple[Node, Node]], label:EdgeLabels) -> None:
+    def add_edges(edges:list[tuple[Node, Node]], label:EdgeLabel) -> None:
         for node0, node1 in edges:
-            process_graph.add_edge(node0, node1, label=label)
+            hb_graph.add_edge(node0, node1, label=label)
     
-    add_edges(program_order_edges, EdgeLabels.PROGRAM_ORDER)
-    add_edges(exec_edges, EdgeLabels.EXEC)
-    add_edges(fork_join_edges, EdgeLabels.FORK_JOIN)
-    return process_graph
+    add_edges(program_order_edges, EdgeLabel.PROGRAM_ORDER)
+    add_edges(exec_edges, EdgeLabel.EXEC)
+    add_edges(fork_join_edges, EdgeLabel.FORK_JOIN)
+    return hb_graph
 
-def traverse_hb_for_dfgraph(process_tree_prov_log: ProvLog, starting_node: Node, traversed: set[int] , dataflow_graph:nx.DiGraph, cmd_map: dict[int, list[str]], inode_version_map: dict[int, set[FileVersion]]) -> None:
+def traverse_hb_for_dfgraph(probe_log: ProbeLog, starting_node: Node, traversed: set[int] , dataflow_graph: DfGraph, cmd_map: dict[int, list[str]], inode_version_map: dict[int, set[FileVersion]]) -> None:
     starting_pid = starting_node[0]
     
-    starting_op = prov_log_get_node(process_tree_prov_log, starting_node[0], starting_node[1], starting_node[2], starting_node[3])
-    process_graph = provlog_to_digraph(process_tree_prov_log)
+    starting_op = get_op(probe_log, starting_node[0], starting_node[1], starting_node[2], starting_node[3])
+    hb_graph = probe_log_to_hb_graph(probe_log)
     
-    edges = list_edges_from_start_node(process_graph, starting_node)
+    edges = list_edges_from_start_node(hb_graph, starting_node)
     name_map = collections.defaultdict[InodeOnDevice, list[pathlib.Path]](list)
 
     target_nodes = collections.defaultdict[int, list[Node]](list)
@@ -275,8 +277,9 @@ def traverse_hb_for_dfgraph(process_tree_prov_log: ProvLog, starting_node: Node,
         if pid in traversed or tid in traversed:
             continue
         
-        op = prov_log_get_node(process_tree_prov_log, pid, exec_epoch_no, tid, op_index).data
-        next_op = prov_log_get_node(process_tree_prov_log, edge[1][0], edge[1][1], edge[1][2], edge[1][3]).data
+        op = get_op(probe_log, pid, exec_epoch_no, tid, op_index).data
+        next_op = get_op(probe_log, edge[1][0], edge[1][1], edge[1][2], edge[1][3]).data
+
         if isinstance(op, OpenOp):
             access_mode = op.flags & os.O_ACCMODE
             processNode = ProcessNode(pid=pid, cmd=tuple(cmd_map[pid]))
@@ -318,28 +321,29 @@ def traverse_hb_for_dfgraph(process_tree_prov_log: ProvLog, starting_node: Node,
             target_nodes[op.task_id] = list()
         elif isinstance(op, WaitOp) and op.options == 0:
             for node in target_nodes[op.task_id]:
-                traverse_hb_for_dfgraph(process_tree_prov_log, node, traversed, dataflow_graph, cmd_map, inode_version_map)
+                traverse_hb_for_dfgraph(probe_log, node, traversed, dataflow_graph, cmd_map, inode_version_map)
                 traversed.add(node[2])
         # return back to the WaitOp of the parent process
         if isinstance(next_op, WaitOp):
             if next_op.task_id == starting_pid or next_op.task_id == starting_op.pthread_id:
                 return
 
-def provlog_to_dataflow_graph(process_tree_prov_log: ProvLog) -> nx.DiGraph:
-    dataflow_graph = nx.DiGraph()
-    process_graph = provlog_to_digraph(process_tree_prov_log)
-    root_node = [n for n in process_graph.nodes() if process_graph.out_degree(n) > 0 and process_graph.in_degree(n) == 0][0]
+
+def probe_log_to_dataflow_graph(probe_log: ProbeLog) -> DfGraph:
+    dataflow_graph = DfGraph()
+    hb_graph = probe_log_to_hb_graph(probe_log)
+    root_node = [n for n in hb_graph.nodes() if hb_graph.out_degree(n) > 0 and hb_graph.in_degree(n) == 0][0]
     traversed: set[int] = set()
     cmd_map = collections.defaultdict[int, list[str]](list)
-    for edge in list(nx.edges(process_graph))[::-1]:
+    for edge in list(hb_graph.edges())[::-1]:
         pid, exec_epoch_no, tid, op_index = edge[0]
-        op = prov_log_get_node(process_tree_prov_log, pid, exec_epoch_no, tid, op_index).data
+        op = get_op(probe_log, pid, exec_epoch_no, tid, op_index).data
         if isinstance(op, ExecOp):
             if pid == tid and exec_epoch_no == 0:
                 cmd_map[tid] = [arg.decode(errors="surrogate") for arg in op.argv]
 
     inode_version_map: dict[int, set[FileVersion]] = {}
-    traverse_hb_for_dfgraph(process_tree_prov_log, root_node, traversed, dataflow_graph, cmd_map, inode_version_map)
+    traverse_hb_for_dfgraph(probe_log, root_node, traversed, dataflow_graph, cmd_map, inode_version_map)
 
     file_version: dict[str, int] = {}
     for inode, versions in inode_version_map.items():
@@ -356,23 +360,23 @@ def provlog_to_dataflow_graph(process_tree_prov_log: ProvLog) -> nx.DiGraph:
 
     return dataflow_graph
 
-def prov_log_get_node(prov_log: ProvLog, pid: int, exec_epoch: int, tid: int, op_no: int) -> Op:
-    return prov_log.processes[pid].exec_epochs[exec_epoch].threads[tid].ops[op_no]
+def get_op(probe_log: ProbeLog, pid: int, exec_epoch: int, tid: int, op_no: int) -> Op:
+    return probe_log.processes[pid].execs[exec_epoch].threads[tid].ops[op_no]
 
 
-def validate_hb_closes(provlog: ProvLog, process_graph: nx.DiGraph) -> list[str]:
+def validate_hb_closes(probe_log: ProbeLog, hb_graph: HbGraph) -> list[str]:
     # Note that this test doesn't work if a process "intentionally" leaves a fd open for its child.
     # E.g., bash-in-pipe
-    provlog_reverse = process_graph.reverse()
+    reservse_hb_graph = hb_graph.reverse()
     ret = list[str]()
     reserved_fds = {0, 1, 2}
-    for node in process_graph.nodes:
-        op = prov_log_get_node(provlog, *node)
+    for node in hb_graph.nodes():
+        op = get_op(probe_log, *node)
         if isinstance(op.data, CloseOp) and op.data.ferrno == 0:
             for closed_fd in range(op.data.low_fd, op.data.high_fd + 1):
                 if closed_fd not in reserved_fds:
-                    for pred_node in nx.dfs_preorder_nodes(provlog_reverse, node):
-                        pred_op = prov_log_get_node(provlog, *pred_node)
+                    for pred_node in nx.dfs_preorder_nodes(reservse_hb_graph, node):
+                        pred_op = get_op(probe_log, *pred_node)
                         if isinstance(pred_op.data, OpenOp) and pred_op.data.fd == closed_fd and op.data.ferrno == 0:
                             break
                     else:
@@ -380,14 +384,15 @@ def validate_hb_closes(provlog: ProvLog, process_graph: nx.DiGraph) -> list[str]
     return ret
 
 
-def validate_hb_waits(provlog: ProvLog, process_graph: nx.DiGraph) -> list[str]:
-    provlog_reverse = process_graph.reverse()
+def validate_hb_waits(probe_log: ProbeLog, hb_graph: HbGraph) -> list[str]:
+    reservse_hb_graph = hb_graph.reverse()
+
     ret = list[str]()
-    for node in process_graph.nodes:
-        op = prov_log_get_node(provlog, *node)
+    for node in hb_graph.nodes():
+        op = get_op(probe_log, *node)
         if isinstance(op.data, WaitOp) and op.data.ferrno == 0:
-            for pred_node in nx.dfs_preorder_nodes(provlog_reverse, node):
-                pred_op = prov_log_get_node(provlog, *pred_node)
+            for pred_node in nx.dfs_preorder_nodes(reservse_hb_graph, node):
+                pred_op = get_op(probe_log, *pred_node)
                 pid1, eid1, tid1, opid1 = pred_node
                 if isinstance(pred_op.data, CloneOp) and pred_op.data.task_type == op.data.task_type and pred_op.data.task_id == op.data.task_id and op.data.ferrno == 0:
                     break
@@ -395,14 +400,14 @@ def validate_hb_waits(provlog: ProvLog, process_graph: nx.DiGraph) -> list[str]:
                 ret.append(f"Wait of {op.data.task_id} in {node} is not preceeded by corresponding clone")
     return ret
 
-def validate_hb_clones(provlog: ProvLog, process_graph: nx.DiGraph) -> list[str]:
+def validate_hb_clones(probe_log: ProbeLog, hb_graph: HbGraph) -> list[str]:
     ret = list[str]()
-    for node in process_graph.nodes:
-        op = prov_log_get_node(provlog, *node)
+    for node in hb_graph.nodes():
+        op = get_op(probe_log, *node)
         if isinstance(op.data, CloneOp) and op.data.ferrno == 0:
-            for node1 in process_graph.successors(node):
+            for node1 in hb_graph.successors(node):
                 pid1, exid1, tid1, op_no1 = node1
-                op1 = prov_log_get_node(provlog, *node1)
+                op1 = get_op(probe_log, *node1)
                 if False:
                     pass
                 elif op.data.task_type == TaskType.TASK_PID:
@@ -424,17 +429,17 @@ def validate_hb_clones(provlog: ProvLog, process_graph: nx.DiGraph) -> list[str]
     return ret
 
 
-def validate_hb_degree(provlog: ProvLog, process_graph: nx.DiGraph) -> list[str]:
+def validate_hb_degree(probe_log: ProbeLog, hb_graph: HbGraph) -> list[str]:
     ret = list[str]()
     found_entry = False
     found_exit = False
-    for node in process_graph.nodes:
-        if process_graph.in_degree(node) == 0:
+    for node in hb_graph.nodes():
+        if hb_graph.in_degree(node) == 0:
             if not found_entry:
                 found_entry = True
             else:
                 ret.append(f"Node {node} has no predecessors")
-        if process_graph.out_degree(node) == 0:
+        if hb_graph.out_degree(node) == 0:
             if not found_exit:
                 found_exit = True
             else:
@@ -446,24 +451,24 @@ def validate_hb_degree(provlog: ProvLog, process_graph: nx.DiGraph) -> list[str]
     return ret
 
 
-def validate_hb_acyclic(provlog: ProvLog, process_graph: nx.DiGraph) -> list[str]:
+def validate_hb_acyclic(probe_log: ProbeLog, hb_graph: HbGraph) -> list[str]:
     try:
-        cycle = nx.find_cycle(process_graph)
+        cycle = nx.find_cycle(hb_graph)
     except nx.NetworkXNoCycle:
         return []
     else:
         return [f"Cycle detected: {cycle}"]
 
 
-def validate_hb_execs(provlog: ProvLog, process_graph: nx.DiGraph) -> list[str]:
+def validate_hb_execs(probe_log: ProbeLog, hb_graph: HbGraph) -> list[str]:
     ret = list[str]()
-    for node0 in process_graph.nodes():
-        pid0, eid0, tid0, op0 = node0
-        op0 = prov_log_get_node(provlog, *node0)
+    for node0 in hb_graph.nodes():
+        pid0, eid0, tid0, _ = node0
+        op0 = get_op(probe_log, *node0)
         if isinstance(op0.data, ExecOp):
-            for node1 in process_graph.successors(node0):
-                pid1, eid1, tid1, op1 = node1
-                op1 = prov_log_get_node(provlog, *node1)
+            for node1 in hb_graph.successors(node0):
+                pid1, eid1, tid1, _ = node1
+                op1 = get_op(probe_log, *node1)
                 if isinstance(op1.data, InitExecEpochOp):
                     if eid0 + 1 != eid1:
                         ret.append(f"ExecOp {node0} is followed by {node1}, whose exec epoch id should be {eid0 + 1}")
@@ -473,7 +478,7 @@ def validate_hb_execs(provlog: ProvLog, process_graph: nx.DiGraph) -> list[str]:
     return ret
 
 
-def validate_hb_graph(processes: ProvLog, hb_graph: nx.DiGraph) -> list[str]:
+def validate_hb_graph(processes: ProbeLog, hb_graph: HbGraph) -> list[str]:
     ret = list[str]()
     # ret.extend(validate_hb_closes(processes, hb_graph))
     ret.extend(validate_hb_waits(processes, hb_graph))
@@ -494,21 +499,22 @@ def relax_node(graph: nx.DiGraph, node: typing.Any) -> list[tuple[typing.Any, ty
     graph.remove_node(node)
     return ret
 
-def color_hb_graph(prov_log: ProvLog, process_graph: nx.DiGraph) -> None:
+
+def color_hb_graph(probe_log: ProbeLog, hb_graph: HbGraph) -> None:
     label_color_map = {
-        EdgeLabels.EXEC: 'yellow',
-        EdgeLabels.FORK_JOIN: 'red',
-        EdgeLabels.PROGRAM_ORDER: 'green',
+        EdgeLabel.EXEC: 'yellow',
+        EdgeLabel.FORK_JOIN: 'red',
+        EdgeLabel.PROGRAM_ORDER: 'green',
     }
 
-    for node0, node1, attrs in process_graph.edges(data=True):
-        label: EdgeLabels = attrs['label']
-        process_graph[node0][node1]['color'] = label_color_map[label]
+    for node0, node1, attrs in hb_graph.edges(data=True):
+        label: EdgeLabel = attrs['label']
+        hb_graph[node0][node1]['color'] = label_color_map[label]
         del attrs['label']
 
-    for node, data in process_graph.nodes(data=True):
+    for node, data in hb_graph.nodes(data=True):
         pid, exid, tid, op_no = node
-        op = prov_log_get_node(prov_log, *node)
+        op = get_op(probe_log, *node)
         typ = type(op.data).__name__
         data["label"] = f"{pid}.{exid}.{tid}.{op_no}\n{typ}"
         if False:
@@ -526,14 +532,14 @@ def color_hb_graph(prov_log: ProvLog, process_graph: nx.DiGraph) -> None:
             data["label"] += f"\n{op.data.path.path.decode()}"
 
 
-def provlog_to_process_tree(prov_log: ProvLog) -> nx.DiGraph:
+def probe_log_to_process_tree(probe_log: ProbeLog) -> nx.DiGraph:
     G = nx.DiGraph()
 
     def epoch_node_id(pid: int, epoch_no: int) -> str:
         return f"pid{pid}_epoch{epoch_no}"
 
-    for pid, process in prov_log.processes.items():
-        for epoch_no, epoch in process.exec_epochs.items():
+    for pid, process in probe_log.processes.items():
+        for epoch_no, epoch in process.execs.items():
             cmd_args = None
 
             for tid, thread in epoch.threads.items():
@@ -555,8 +561,8 @@ def provlog_to_process_tree(prov_log: ProvLog) -> nx.DiGraph:
             node_id = epoch_node_id(pid, epoch_no)
             G.add_node(node_id, label=label)
 
-    for pid, process in prov_log.processes.items():
-        for exec_epoch_no, exec_epoch in process.exec_epochs.items():
+    for pid, process in probe_log.processes.items():
+        for exec_epoch_no, exec_epoch in process.execs.items():
             parent_node_id = epoch_node_id(pid, exec_epoch_no)
 
             for tid, thread in exec_epoch.threads.items():
@@ -565,7 +571,7 @@ def provlog_to_process_tree(prov_log: ProvLog) -> nx.DiGraph:
 
                     if isinstance(op_data, CloneOp) and op_data.ferrno == 0:
                         child_pid = op_data.task_id
-                        if child_pid in prov_log.processes:
+                        if child_pid in probe_log.processes:
                             child_epoch = 0
                             child_node_id = epoch_node_id(child_pid, child_epoch)
 
@@ -581,7 +587,7 @@ def provlog_to_process_tree(prov_log: ProvLog) -> nx.DiGraph:
 
     return G
 
-def get_max_parallelism_latest(graph: nx.DiGraph, prov_log: ProvLog) -> int:
+def get_max_parallelism_latest(graph: DfGraph, probe_log: ProbeLog) -> int:
     visited = set()
     # counter is set to 1 to include the main parent process
     counter = 1 
@@ -595,8 +601,8 @@ def get_max_parallelism_latest(graph: nx.DiGraph, prov_log: ProvLog) -> int:
         pid, exec_epoch_no, tid, op_index = node
         if(parent):
             parent_pid, parent_exec_epoch_no, parent_tid, parent_op_index = parent
-            parent_op = prov_log_get_node(prov_log, parent_pid, parent_exec_epoch_no, parent_tid, parent_op_index).data
-        node_op = prov_log_get_node(prov_log, pid, exec_epoch_no, tid, op_index).data
+            parent_op = get_op(probe_log, parent_pid, parent_exec_epoch_no, parent_tid, parent_op_index).data
+        node_op = get_op(probe_log, pid, exec_epoch_no, tid, op_index).data
 
         visited.add(node)
 

--- a/probe_py/probe_py/analysis.py
+++ b/probe_py/probe_py/analysis.py
@@ -255,7 +255,7 @@ def probe_log_to_hb_graph(probe_log: ProbeLog) -> HbGraph:
     return hb_graph
 
 
-def traverse_hb_for_dfgraph(probe_log: ProbeLog, starting_node: OpNode, traversed: set[int] , dataflow_graph: DfGraph, cmd_map: dict[int, list[str]], inode_version_map: dict[int, set[FileVersion]], hb_graph: nx.DiGraph) -> None:
+def traverse_hb_for_dfgraph(probe_log: ProbeLog, starting_node: OpNode, traversed: set[int] , dataflow_graph: DfGraph, cmd_map: dict[int, list[str]], inode_version_map: dict[int, set[FileVersion]], hb_graph: HbGraph) -> None:
     starting_pid = starting_node[0]
     
     starting_op = get_op(probe_log, starting_node[0], starting_node[1], starting_node[2], starting_node[3])

--- a/probe_py/probe_py/cli.py
+++ b/probe_py/probe_py/cli.py
@@ -106,7 +106,7 @@ def ops_graph(
         graph_utils.remove_nodes(
             hb_graph,
             lambda node: isinstance(
-                analysis.get_op(prov_log, *node).data, # type: ignore
+                analysis.get_op(probe_log, *node).data, # type: ignore
                 (ops.ExecOp, ops.CloneOp, ops.WaitOp)
             ),
             lambda incoming_edge_label, outgoing_edge_label: outgoing_edge_label,
@@ -133,6 +133,7 @@ def dataflow_graph(
     """
     probe_log = parser.parse_probe_log(path_to_probe_log)
     dataflow_graph = analysis.probe_log_to_dataflow_graph(probe_log)
+    graph_utils.serialize_graph(dataflow_graph, output)
 
 
 def get_host_name() -> int:

--- a/probe_py/probe_py/file_closure.py
+++ b/probe_py/probe_py/file_closure.py
@@ -10,7 +10,7 @@ import shutil
 import warnings
 import pathlib
 import typing
-from .ptypes import ProvLog, InodeVersionLog
+from .ptypes import InodeVersionLog, ProbeLog
 from .ops import Path, ChdirOp, OpenOp, CloseOp, ExecOp, InitExecEpochOp
 from .consts import AT_FDCWD
 
@@ -26,7 +26,7 @@ def build_oci_image(
     if root_pid is None:
         console.print("Could not find root process; Are you sure this probe_log is valid?")
         raise typer.Exit(code=1)
-    first_op = prov_log.processes[root_pid].exec_epochs[0].threads[root_pid].ops[0].data
+    first_op = probe_log.processes[root_pid].execs[0].threads[root_pid].ops[0].data
     if not isinstance(first_op, InitExecEpochOp):
         console.print("First op is not InitExecEpochOp. Are you sure this probe_log is valid?")
         raise typer.Exit(code=1)

--- a/probe_py/probe_py/file_closure.py
+++ b/probe_py/probe_py/file_closure.py
@@ -10,30 +10,30 @@ import shutil
 import warnings
 import pathlib
 import typing
-from .ptypes import ProvLog, InodeVersionLog
+from .ptypes import ProbeLog, InodeVersionLog
 from .ops import Path, ChdirOp, OpenOp, CloseOp, InitProcessOp, ExecOp
 from .consts import AT_FDCWD
 
 
 def build_oci_image(
-        prov_log: ProvLog,
+        probe_log: ProbeLog,
         image_name: str,
         push_docker: bool,
         verbose: bool,
         console: rich.console.Console,
 ) -> None:
-    root_pid = get_root_pid(prov_log)
+    root_pid = get_root_pid(probe_log)
     if root_pid is None:
         console.print("Could not find root process; Are you sure this probe_log is valid?")
         raise typer.Exit(code=1)
-    first_op = prov_log.processes[root_pid].exec_epochs[0].threads[root_pid].ops[0].data
+    first_op = probe_log.processes[root_pid].execs[0].threads[root_pid].ops[0].data
     if not isinstance(first_op, InitProcessOp):
         console.print("First op is not InitProcessOp. Are you sure this probe_log is valid?")
         raise typer.Exit(code=1)
     with tempfile.TemporaryDirectory() as _tmpdir:
         tmpdir = pathlib.Path(_tmpdir)
         copy_file_closure(
-            prov_log,
+            probe_log,
             tmpdir,
             copy=True,
             verbose=verbose,
@@ -66,11 +66,11 @@ def build_oci_image(
         )
 
         # Set up other config (env, cmd, entrypoint)
-        pid = get_root_pid(prov_log)
+        pid = get_root_pid(probe_log)
         if pid is None:
             console.print("Could not find root process; Are you sure this probe_log is valid?")
             raise typer.Exit(code=1)
-        last_op = prov_log.processes[pid].exec_epochs[0].threads[pid].ops[-1].data
+        last_op = probe_log.processes[pid].execs[0].threads[pid].ops[-1].data
         if not isinstance(last_op, ExecOp):
             console.print(f"Last op is not ExecOp: {last_op}. Are you sure this probe_log is valid?")
             raise typer.Exit(code=1)
@@ -131,33 +131,33 @@ def build_oci_image(
 
 
 def copy_file_closure(
-        prov_log: ProvLog,
+        probe_log: ProbeLog,
         destination: pathlib.Path,
         copy: bool,
         verbose: bool,
         console: rich.console.Console,
 ) -> None:
-    """Extract files used by the application recoreded in prov_log to destination
+    """Extract files used by the application recoreded in probe_log to destination
 
-    If the required file are recorded in prov_log, we will use that.
-    However, prov_log only captures files that get mutated _during the $cmd_.
+    If the required file are recorded in probe_log, we will use that.
+    However, probe_log only captures files that get mutated _during the $cmd_.
     We assume the rest of the files will not change between the time of `probe record $cmd` and `probe oci-image`.
     (so probably run those back-to-back).
-    For the files not included in prov_log, we will use the current copy on-disk.
-    However, we will test to ensure it is the same version as recorded in prov_log.
+    For the files not included in probe_log, we will use the current copy on-disk.
+    However, we will test to ensure it is the same version as recorded in probe_log.
 
     `copy` refers to whether we should copy files from disk or symlink them.
     """
 
     to_copy = dict[pathlib.Path, Path | None]()
     to_copy_exes = dict[pathlib.Path, Path | None]()
-    for pid, process in prov_log.processes.items():
-        for exec_epoch_no, exec_epoch in process.exec_epochs.items():
-            root_pid = get_root_pid(prov_log)
+    for pid, process in probe_log.processes.items():
+        for exec_epoch_no, exec_epoch in process.execs.items():
+            root_pid = get_root_pid(probe_log)
             if root_pid is None:
                 console.print("Could not find root process; Are you sure this probe_log is valid?")
                 raise typer.Exit(code=1)
-            first_op = prov_log.processes[root_pid].exec_epochs[0].threads[root_pid].ops[0].data
+            first_op = probe_log.processes[root_pid].execs[0].threads[root_pid].ops[0].data
             if not isinstance(first_op, InitProcessOp):
                 console.print("First op is not InitProcessOp. Are you sure this probe_log is valid?")
                 raise typer.Exit(code=1)
@@ -198,7 +198,7 @@ def copy_file_closure(
         _get_dlibs(resolved_path, dependent_dlibs)
         for dependent_dlib in dependent_dlibs:
             to_copy[pathlib.Path(dependent_dlib)] = None
-    inodes = prov_log.inodes
+    inodes = probe_log.inodes
     if inodes is None:
         raise ValueError("PROBE log appears to not contain inodes")
     for resolved_path, maybe_path in to_copy.items():
@@ -220,7 +220,7 @@ def copy_file_closure(
             # When the tar archive gets deleted, these inodes will remain.
             destination_path.hardlink_to(inode_content)
             if verbose:
-                console.print(f"Hardlinking {resolved_path} from prov_log")
+                console.print(f"Hardlinking {resolved_path} from probe_log")
         elif any(resolved_path.is_relative_to(forbidden_path) for forbidden_path in forbidden_paths):
             if verbose:
                 console.print(f"Skipping {resolved_path}")
@@ -253,10 +253,10 @@ def resolve_path(
         raise KeyError(f"dirfd {path.dirfd} not found in fd table")
 
 
-def get_root_pid(prov_log: ProvLog) -> int | None:
+def get_root_pid(probe_log: ProbeLog) -> int | None:
     possible_root = []
-    for pid, process in prov_log.processes.items():
-        first_op = process.exec_epochs[0].threads[pid].ops[0].data
+    for pid, process in probe_log.processes.items():
+        first_op = process.execs[0].threads[pid].ops[0].data
         if isinstance(first_op, InitProcessOp):
             possible_root.append(pid)
     if possible_root:

--- a/probe_py/probe_py/ptypes.py
+++ b/probe_py/probe_py/ptypes.py
@@ -2,29 +2,18 @@ from __future__ import annotations
 import pathlib
 from . import ops
 import os
-from dataclasses import dataclass
+import dataclasses
 import enum
 import typing
 
 
-@dataclass(frozen=True)
-class ThreadProvLog:
-    tid: int
-    ops: typing.Sequence[ops.Op]
 
-@dataclass(frozen=True)
-class ExecEpochProvLog:
-    epoch: int
-    threads: typing.Mapping[int, ThreadProvLog]
+@dataclasses.dataclass(frozen=True)
+class ProbeOptions:
+    copy_files: bool
 
 
-@dataclass(frozen=True)
-class ProcessProvLog:
-    pid: int
-    exec_epochs: typing.Mapping[int, ExecEpochProvLog]
-
-
-@dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True)
 class InodeVersionLog:
     device_major: int
     device_minor: int
@@ -45,10 +34,32 @@ class InodeVersionLog:
             s.st_size,
         )
 
+Tid: typing.TypeAlias = int
+Pid: typing.TypeAlias = int
+ExecNo: typing.TypeAlias = int
 
-@dataclass(frozen=True)
-class ProvLog:
-    processes: typing.Mapping[int, ProcessProvLog]
+
+@dataclasses.dataclass(frozen=True)
+class KernelThread:
+    tid: Tid
+    ops: typing.Sequence[ops.Op]
+
+
+@dataclasses.dataclass(frozen=True)
+class Exec:
+    exec_no: ExecNo
+    threads: typing.Mapping[Tid, KernelThread]
+
+
+@dataclasses.dataclass(frozen=True)
+class Process:
+    pid: Pid
+    execs: typing.Mapping[ExecNo, Exec]
+
+
+@dataclasses.dataclass(frozen=True)
+class ProbeLog:
+    processes: typing.Mapping[Pid, Process]
     inodes: typing.Mapping[InodeVersionLog, pathlib.Path] | None
     has_inodes: bool
 

--- a/probe_py/probe_py/workflows.py
+++ b/probe_py/probe_py/workflows.py
@@ -1,4 +1,4 @@
-from probe_py.analysis import ProcessNode, FileNode
+from probe_py.analysis import ProcessNode, FileNode, DfGraph
 import networkx as nx # type: ignore
 import abc
 from typing import List, Set, Optional
@@ -24,7 +24,7 @@ All the cases we should take care of:
 """
 class WorkflowGenerator(abc.ABC):
     @abc.abstractmethod
-    def generate_workflow(self, graph: nx.DiGraph) -> str:
+    def generate_workflow(self, graph: DfGraph) -> str:
         pass
 
 class NextflowGenerator(WorkflowGenerator):
@@ -256,7 +256,7 @@ process process_{id(process)} {{
 
                 self.visited.add(node)
   
-    def generate_workflow(self, graph: nx.DiGraph) -> str:  
+    def generate_workflow(self, graph: DfGraph) -> str:
         """
         Generate the complete Nextflow workflow script from the graph.
         """
@@ -383,7 +383,7 @@ class MakefileGenerator:
                 
                 self.handle_process_node(node, inputs, outputs)
 
-    def generate_makefile(self, graph: nx.DiGraph) -> str:
+    def generate_makefile(self, graph: DfGraph) -> str:
         """
         Generate the complete Makefile script from the graph.
         """

--- a/probe_py/tests/test_graph.py
+++ b/probe_py/tests/test_graph.py
@@ -23,8 +23,8 @@ def test_diff_cmd() -> None:
     hb_graph = probe_log_to_hb_graph(probe_log)
     assert not validate_hb_graph(probe_log, hb_graph)
     path_bytes = [path.encode() for path in paths]
-    dfs_edges = list(nx.dfs_edges(process_graph))
-    match_open_and_close_fd(dfs_edges, process_tree_probe_log, path_bytes)
+    dfs_edges = list(nx.dfs_edges(hb_graph))
+    match_open_and_close_fd(dfs_edges, probe_log, path_bytes)
 
 
 def test_bash_in_bash() -> None:
@@ -36,28 +36,28 @@ def test_bash_in_bash() -> None:
     process_file_map = {}
     start_node = [
         node
-        for node in process_graph.nodes()
-        if process_graph.in_degree(node) == 0
+        for node in hb_graph.nodes()
+        if hb_graph.in_degree(node) == 0
     ][0]
-    dfs_edges = list(nx.dfs_edges(process_graph,source=start_node))
+    dfs_edges = list(nx.dfs_edges(hb_graph,source=start_node))
     parent_process_id = dfs_edges[0][0][0]
     process_file_map[f"{project_root}/flake.lock".encode()] = parent_process_id
     process_file_map[f"{project_root}/flake.nix".encode()] = parent_process_id
-    check_for_clone_and_open(dfs_edges, process_tree_probe_log, 1, process_file_map, paths)
+    check_for_clone_and_open(dfs_edges, probe_log, 1, process_file_map, paths)
 
 def test_bash_in_bash_pipe() -> None:
     command = ["bash", "-c", f"head {project_root}/flake.nix | tail"]
     probe_log = execute_command(command)
-    process_graph = probe_log_to_hb_graph(probe_log)
+    hb_graph = probe_log_to_hb_graph(probe_log)
     assert not validate_hb_graph(probe_log, hb_graph)
     paths = [f'{project_root}/flake.nix'.encode(), b'stdout']
     start_node = [
         node
-        for node in process_graph.nodes()
-        if process_graph.in_degree(node) == 0
+        for node in hb_graph.nodes()
+        if hb_graph.in_degree(node) == 0
     ][0]
-    dfs_edges = list(nx.dfs_edges(process_graph,source=start_node))
-    check_for_clone_and_open(dfs_edges, process_tree_probe_log, len(paths), {}, paths)
+    dfs_edges = list(nx.dfs_edges(hb_graph,source=start_node))
+    check_for_clone_and_open(dfs_edges, probe_log, len(paths), {}, paths)
 
 
 @pytest.mark.xfail
@@ -65,13 +65,13 @@ def test_pthreads() -> None:
     probe_log = execute_command([f"{project_root}/tests/examples/createFile.exe"])
     hb_graph = probe_log_to_hb_graph(probe_log)
     assert not validate_hb_graph(probe_log, hb_graph)
-    root_node = [n for n in process_graph.nodes() if process_graph.out_degree(n) > 0 and process_graph.in_degree(n) == 0][0]
-    bfs_nodes = [node for layer in nx.bfs_layers(process_graph, root_node) for node in layer]
-    root_node = [n for n in process_graph.nodes() if process_graph.out_degree(n) > 0 and process_graph.in_degree(n) == 0][0]
-    dfs_edges = list(nx.dfs_edges(process_graph,source=root_node))
+    root_node = [n for n in hb_graph.nodes() if hb_graph.out_degree(n) > 0 and hb_graph.in_degree(n) == 0][0]
+    bfs_nodes = [node for layer in nx.bfs_layers(hb_graph, root_node) for node in layer]
+    root_node = [n for n in hb_graph.nodes() if hb_graph.out_degree(n) > 0 and hb_graph.in_degree(n) == 0][0]
+    dfs_edges = list(nx.dfs_edges(hb_graph,source=root_node))
     total_pthreads = 3
     paths = [b'/tmp/0.txt', b'/tmp/1.txt', b'/tmp/2.txt']
-    check_pthread_graph(bfs_nodes, dfs_edges, process_tree_probe_log, total_pthreads, paths)
+    check_pthread_graph(bfs_nodes, dfs_edges, probe_log, total_pthreads, paths)
     
 def execute_command(command: list[str], return_code: int = 0) -> ProbeLog:
     input = pathlib.Path("probe_log")
@@ -90,13 +90,13 @@ def execute_command(command: list[str], return_code: int = 0) -> ProbeLog:
     # assert result.returncode == return_code
     assert result.returncode == 0
     assert input.exists()
-    process_tree_probe_log = parse_probe_log(input)
-    return process_tree_probe_log
+    probe_log = parse_probe_log(input)
+    return probe_log
 
 
 def check_for_clone_and_open(
         dfs_edges: typing.Sequence[tuple[Node, Node]],
-        process_tree_probe_log: ProbeLog,
+        probe_log: ProbeLog,
         number_of_child_process: int,
         process_file_map: dict[bytes, Pid],
         paths: list[bytes],
@@ -116,11 +116,11 @@ def check_for_clone_and_open(
     for edge in dfs_edges:
         curr_pid, curr_epoch_idx, curr_tid, curr_op_idx = edge[0]
         
-        curr_node_op = get_op_from_probe_log(process_tree_probe_log, curr_pid, curr_epoch_idx, curr_tid, curr_op_idx)
+        curr_node_op = get_op_from_probe_log(probe_log, curr_pid, curr_epoch_idx, curr_tid, curr_op_idx)
         if curr_node_op is not None:
             curr_node_op_data = curr_node_op.data
         if(isinstance(curr_node_op_data,CloneOp)):
-            next_op = get_op_from_probe_log(process_tree_probe_log, edge[1][0], edge[1][1], edge[1][2], edge[1][3])
+            next_op = get_op_from_probe_log(probe_log, edge[1][0], edge[1][1], edge[1][2], edge[1][3])
             if next_op is not None:
                 next_op_data = next_op.data
             if isinstance(next_op_data,ExecOp):
@@ -169,7 +169,7 @@ def check_for_clone_and_open(
             # check if stdout is read in right child process
             if(edge[1][3]==-1):
                 continue
-            next_init_op = get_op_from_probe_log(process_tree_probe_log,curr_pid,1,curr_pid,0)
+            next_init_op = get_op_from_probe_log(probe_log,curr_pid,1,curr_pid,0)
             if next_init_op is not None:
                 next_init_op_data = next_init_op.data
                 assert isinstance(next_init_op_data, InitExecEpochOp)
@@ -188,14 +188,14 @@ def check_for_clone_and_open(
 
 def match_open_and_close_fd(
         dfs_edges: typing.Sequence[tuple[Node, Node]],
-        process_tree_probe_log: ProbeLog,
+        probe_log: ProbeLog,
         paths: list[bytes],
 ) -> None:
     reserved_file_descriptors = [0, 1, 2]
     file_descriptors = set[int]()
     for edge in dfs_edges:
         curr_pid, curr_epoch_idx, curr_tid, curr_op_idx = edge[0]
-        curr_node_op = get_op_from_probe_log(process_tree_probe_log, curr_pid, curr_epoch_idx, curr_tid, curr_op_idx)
+        curr_node_op = get_op_from_probe_log(probe_log, curr_pid, curr_epoch_idx, curr_tid, curr_op_idx)
         if curr_node_op is not None:
             curr_node_op_data = curr_node_op.data
         if(isinstance(curr_node_op_data,OpenOp)):
@@ -218,7 +218,7 @@ def match_open_and_close_fd(
 def check_pthread_graph(
         bfs_nodes: typing.Sequence[Node],
         dfs_edges: typing.Sequence[tuple[Node, Node]],
-        process_tree_probe_log: ProbeLog,
+        probe_log: ProbeLog,
         total_pthreads: int,
         paths: list[bytes],
 ) -> None:
@@ -228,11 +228,11 @@ def check_pthread_graph(
     file_descriptors = set[int]()
     reserved_file_descriptors = [1, 2, 3]
     edge = dfs_edges[0]
-    parent_pthread_id = get_op_from_probe_log(process_tree_probe_log, edge[0][0], edge[0][1], edge[0][2], edge[0][3]).pthread_id
+    parent_pthread_id = get_op_from_probe_log(probe_log, edge[0][0], edge[0][1], edge[0][2], edge[0][3]).pthread_id
 
     for edge in dfs_edges:
         curr_pid, curr_epoch_idx, curr_tid, curr_op_idx = edge[0]
-        curr_node_op = get_op_from_probe_log(process_tree_probe_log, curr_pid, curr_epoch_idx, curr_tid, curr_op_idx)
+        curr_node_op = get_op_from_probe_log(probe_log, curr_pid, curr_epoch_idx, curr_tid, curr_op_idx)
         if(isinstance(curr_node_op.data,CloneOp)):
             if edge[1][2] != curr_tid:
                continue
@@ -250,7 +250,7 @@ def check_pthread_graph(
     assert len(set(bfs_nodes)) == len(bfs_nodes)
     for node in bfs_nodes:
         curr_pid, curr_epoch_idx, curr_tid, curr_op_idx = node
-        curr_node_op = get_op_from_probe_log(process_tree_probe_log, curr_pid, curr_epoch_idx, curr_tid, curr_op_idx)
+        curr_node_op = get_op_from_probe_log(probe_log, curr_pid, curr_epoch_idx, curr_tid, curr_op_idx)
         if curr_node_op is not None and (isinstance(curr_node_op.data,OpenOp)):
             file_descriptors.add(curr_node_op.data.fd)
             path = curr_node_op.data.path.path
@@ -278,7 +278,7 @@ def check_pthread_graph(
     assert len(file_descriptors) == 0
 
 def get_op_from_probe_log(
-        process_tree_probe_log: ProbeLog,
+        probe_log: ProbeLog,
         pid: Pid,
         exec_epoch_id: ExecNo,
         tid: Tid,
@@ -286,4 +286,4 @@ def get_op_from_probe_log(
 ) -> Op:
     if op_idx == -1 or exec_epoch_id == -1:
         raise ValueError()
-    return process_tree_probe_log.processes[pid].execs[exec_epoch_id].threads[tid].ops[op_idx]
+    return probe_log.processes[pid].execs[exec_epoch_id].threads[tid].ops[op_idx]

--- a/probe_py/tests/test_graph.py
+++ b/probe_py/tests/test_graph.py
@@ -1,9 +1,9 @@
 import pytest
 import typing
 from probe_py.parser import parse_probe_log
-from probe_py.ptypes import ProvLog
+from probe_py.ptypes import ProbeLog
 from probe_py.ops import OpenOp, CloneOp, ExecOp, InitProcessOp, InitExecEpochOp, CloseOp, WaitOp, Op
-from probe_py.analysis import provlog_to_digraph, validate_hb_graph
+from probe_py.analysis import probe_log_to_digraph, validate_hb_graph
 import pathlib
 import networkx as nx  # type: ignore
 import subprocess
@@ -19,19 +19,19 @@ project_root = pathlib.Path(__file__).resolve().parent.parent.parent
 def test_diff_cmd() -> None:
     paths = [str(project_root / "flake.nix"), str(project_root / "flake.lock")]
     command = ['diff', *paths]
-    process_tree_prov_log = execute_command(command, 1)
-    process_graph = provlog_to_digraph(process_tree_prov_log)
-    assert not validate_hb_graph(process_tree_prov_log, process_graph)
+    process_tree_probe_log = execute_command(command, 1)
+    process_graph = probe_log_to_digraph(process_tree_probe_log)
+    assert not validate_hb_graph(process_tree_probe_log, process_graph)
     path_bytes = [path.encode() for path in paths]
     dfs_edges = list(nx.dfs_edges(process_graph))
-    match_open_and_close_fd(dfs_edges, process_tree_prov_log, path_bytes)
+    match_open_and_close_fd(dfs_edges, process_tree_probe_log, path_bytes)
 
 
 def test_bash_in_bash() -> None:
     command = ["bash", "-c", f"head {project_root}/flake.nix ; head {project_root}/flake.lock"]
-    process_tree_prov_log = execute_command(command)
-    process_graph = provlog_to_digraph(process_tree_prov_log)
-    assert not validate_hb_graph(process_tree_prov_log, process_graph)
+    process_tree_probe_log = execute_command(command)
+    process_graph = probe_log_to_digraph(process_tree_probe_log)
+    assert not validate_hb_graph(process_tree_probe_log, process_graph)
     paths = [f'{project_root}/flake.nix'.encode(), f'{project_root}/flake.lock'.encode()]
     process_file_map = {}
     start_node = [node for node, degree in process_graph.in_degree() if degree == 0][0]
@@ -39,33 +39,33 @@ def test_bash_in_bash() -> None:
     parent_process_id = dfs_edges[0][0][0]
     process_file_map[f"{project_root}/flake.lock".encode()] = parent_process_id
     process_file_map[f"{project_root}/flake.nix".encode()] = parent_process_id
-    check_for_clone_and_open(dfs_edges, process_tree_prov_log, 1, process_file_map, paths)
+    check_for_clone_and_open(dfs_edges, process_tree_probe_log, 1, process_file_map, paths)
 
 def test_bash_in_bash_pipe() -> None:
     command = ["bash", "-c", f"head {project_root}/flake.nix | tail"]
-    process_tree_prov_log = execute_command(command)
-    process_graph = provlog_to_digraph(process_tree_prov_log)
-    assert not validate_hb_graph(process_tree_prov_log, process_graph)
+    process_tree_probe_log = execute_command(command)
+    process_graph = probe_log_to_digraph(process_tree_probe_log)
+    assert not validate_hb_graph(process_tree_probe_log, process_graph)
     paths = [f'{project_root}/flake.nix'.encode(), b'stdout']
     start_node = [node for node, degree in process_graph.in_degree() if degree == 0][0]
     dfs_edges = list(nx.dfs_edges(process_graph,source=start_node))
-    check_for_clone_and_open(dfs_edges, process_tree_prov_log, len(paths), {}, paths)
+    check_for_clone_and_open(dfs_edges, process_tree_probe_log, len(paths), {}, paths)
 
 
 @pytest.mark.xfail
 def test_pthreads() -> None:
-    process_tree_prov_log = execute_command([f"{project_root}/probe_src/tests/c/createFile.exe"])
-    process_graph = provlog_to_digraph(process_tree_prov_log)
-    assert not validate_hb_graph(process_tree_prov_log, process_graph)
+    process_tree_probe_log = execute_command([f"{project_root}/probe_src/tests/c/createFile.exe"])
+    process_graph = probe_log_to_digraph(process_tree_probe_log)
+    assert not validate_hb_graph(process_tree_probe_log, process_graph)
     root_node = [n for n in process_graph.nodes() if process_graph.out_degree(n) > 0 and process_graph.in_degree(n) == 0][0]
     bfs_nodes = [node for layer in nx.bfs_layers(process_graph, root_node) for node in layer]
     root_node = [n for n in process_graph.nodes() if process_graph.out_degree(n) > 0 and process_graph.in_degree(n) == 0][0]
     dfs_edges = list(nx.dfs_edges(process_graph,source=root_node))
     total_pthreads = 3
     paths = [b'/tmp/0.txt', b'/tmp/1.txt', b'/tmp/2.txt']
-    check_pthread_graph(bfs_nodes, dfs_edges, process_tree_prov_log, total_pthreads, paths)
+    check_pthread_graph(bfs_nodes, dfs_edges, process_tree_probe_log, total_pthreads, paths)
     
-def execute_command(command: list[str], return_code: int = 0) -> ProvLog:
+def execute_command(command: list[str], return_code: int = 0) -> ProbeLog:
     input = pathlib.Path("probe_log")
     if input.exists():
         input.unlink()
@@ -82,13 +82,13 @@ def execute_command(command: list[str], return_code: int = 0) -> ProvLog:
     # assert result.returncode == return_code
     assert result.returncode == 0
     assert input.exists()
-    process_tree_prov_log = parse_probe_log(input)
-    return process_tree_prov_log
+    process_tree_probe_log = parse_probe_log(input)
+    return process_tree_probe_log
 
 
 def check_for_clone_and_open(
         dfs_edges: typing.Sequence[tuple[Node, Node]],
-        process_tree_prov_log: ProvLog,
+        process_tree_probe_log: ProbeLog,
         number_of_child_process: int,
         process_file_map: dict[bytes, int],
         paths: list[bytes],
@@ -108,11 +108,11 @@ def check_for_clone_and_open(
     for edge in dfs_edges:
         curr_pid, curr_epoch_idx, curr_tid, curr_op_idx = edge[0]
         
-        curr_node_op = get_op_from_provlog(process_tree_prov_log, curr_pid, curr_epoch_idx, curr_tid, curr_op_idx)
+        curr_node_op = get_op_from_probe_log(process_tree_probe_log, curr_pid, curr_epoch_idx, curr_tid, curr_op_idx)
         if curr_node_op is not None:
             curr_node_op_data = curr_node_op.data
         if(isinstance(curr_node_op_data,CloneOp)):
-            next_op = get_op_from_provlog(process_tree_prov_log, edge[1][0], edge[1][1], edge[1][2], edge[1][3])
+            next_op = get_op_from_probe_log(process_tree_probe_log, edge[1][0], edge[1][1], edge[1][2], edge[1][3])
             if next_op is not None:
                 next_op_data = next_op.data
             if isinstance(next_op_data,ExecOp):
@@ -161,7 +161,7 @@ def check_for_clone_and_open(
             # check if stdout is read in right child process
             if(edge[1][3]==-1):
                 continue
-            next_init_op = get_op_from_provlog(process_tree_prov_log,curr_pid,1,curr_pid,0)
+            next_init_op = get_op_from_probe_log(process_tree_probe_log,curr_pid,1,curr_pid,0)
             if next_init_op is not None:
                 next_init_op_data = next_init_op.data
                 assert isinstance(next_init_op_data, InitExecEpochOp)
@@ -180,14 +180,14 @@ def check_for_clone_and_open(
 
 def match_open_and_close_fd(
         dfs_edges: typing.Sequence[tuple[Node, Node]],
-        process_tree_prov_log: ProvLog,
+        process_tree_probe_log: ProbeLog,
         paths: list[bytes],
 ) -> None:
     reserved_file_descriptors = [0, 1, 2]
     file_descriptors = set[int]()
     for edge in dfs_edges:
         curr_pid, curr_epoch_idx, curr_tid, curr_op_idx = edge[0]
-        curr_node_op = get_op_from_provlog(process_tree_prov_log, curr_pid, curr_epoch_idx, curr_tid, curr_op_idx)
+        curr_node_op = get_op_from_probe_log(process_tree_probe_log, curr_pid, curr_epoch_idx, curr_tid, curr_op_idx)
         if curr_node_op is not None:
             curr_node_op_data = curr_node_op.data
         if(isinstance(curr_node_op_data,OpenOp)):
@@ -210,7 +210,7 @@ def match_open_and_close_fd(
 def check_pthread_graph(
         bfs_nodes: typing.Sequence[Node],
         dfs_edges: typing.Sequence[tuple[Node, Node]],
-        process_tree_prov_log: ProvLog,
+        process_tree_probe_log: ProbeLog,
         total_pthreads: int,
         paths: list[bytes],
 ) -> None:
@@ -220,11 +220,11 @@ def check_pthread_graph(
     file_descriptors = set[int]()
     reserved_file_descriptors = [1, 2, 3]
     edge = dfs_edges[0]
-    parent_pthread_id = get_op_from_provlog(process_tree_prov_log, edge[0][0], edge[0][1], edge[0][2], edge[0][3]).pthread_id
+    parent_pthread_id = get_op_from_probe_log(process_tree_probe_log, edge[0][0], edge[0][1], edge[0][2], edge[0][3]).pthread_id
 
     for edge in dfs_edges:
         curr_pid, curr_epoch_idx, curr_tid, curr_op_idx = edge[0]
-        curr_node_op = get_op_from_provlog(process_tree_prov_log, curr_pid, curr_epoch_idx, curr_tid, curr_op_idx)
+        curr_node_op = get_op_from_probe_log(process_tree_probe_log, curr_pid, curr_epoch_idx, curr_tid, curr_op_idx)
         if(isinstance(curr_node_op.data,CloneOp)):
             if edge[1][2] != curr_tid:
                continue
@@ -242,7 +242,7 @@ def check_pthread_graph(
     assert len(set(bfs_nodes)) == len(bfs_nodes)
     for node in bfs_nodes:
         curr_pid, curr_epoch_idx, curr_tid, curr_op_idx = node
-        curr_node_op = get_op_from_provlog(process_tree_prov_log, curr_pid, curr_epoch_idx, curr_tid, curr_op_idx)
+        curr_node_op = get_op_from_probe_log(process_tree_probe_log, curr_pid, curr_epoch_idx, curr_tid, curr_op_idx)
         if curr_node_op is not None and (isinstance(curr_node_op.data,OpenOp)):
             file_descriptors.add(curr_node_op.data.fd)
             path = curr_node_op.data.path.path
@@ -269,8 +269,8 @@ def check_pthread_graph(
     assert len(process_file_map.items()) == len(paths)
     assert len(file_descriptors) == 0
 
-def get_op_from_provlog(
-        process_tree_prov_log: ProvLog,
+def get_op_from_probe_log(
+        process_tree_probe_log: ProbeLog,
         pid: int,
         exec_epoch_id: int,
         tid: int,
@@ -278,4 +278,4 @@ def get_op_from_provlog(
 ) -> Op:
     if op_idx == -1 or exec_epoch_id == -1:
         raise ValueError()
-    return process_tree_prov_log.processes[pid].exec_epochs[exec_epoch_id].threads[tid].ops[op_idx]
+    return process_tree_probe_log.processes[pid].exec_epochs[exec_epoch_id].threads[tid].ops[op_idx]

--- a/probe_py/tests/test_workflow.py
+++ b/probe_py/tests/test_workflow.py
@@ -4,6 +4,7 @@ import pathlib
 import networkx as nx  # type: ignore
 from probe_py.analysis import FileNode, ProcessNode, InodeOnDevice, FileVersion
 from probe_py.workflows import NextflowGenerator
+from probe_py.analysis import DfGraph
 
 
 tmpdir = pathlib.Path(__file__).resolve().parent / "tmp"
@@ -68,7 +69,7 @@ workflow {
     Y = ProcessNode(2,("analyze", "-i", "-k"))
 
 
-    example_dataflow_graph = nx.DiGraph()
+    example_dataflow_graph = DfGraph()
     # FileNodes will be red and ProcessNodes will be blue in the visualization
     # Code can distinguish between the two using isinstance(node, ProcessNode) or likewise with FileNode
     example_dataflow_graph.add_nodes_from([A, B0, B1, C], color="red")

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -68,19 +68,16 @@ commands = {
         ["python", "-c", "print(4)"],
         [true_path],
     ),
-    # bash(
-    #     *bash(
-    #         *bash("echo", "hi", "redirect_to", "file0"),
-    #         "and",
-    #         *bash("cat", "file0", "file0", "redirect_to", "file1"),
-    #     ),
-    #     "and",
-    #     *bash(
-    #         *bash("cat", "file0", "file1", "redirect_to", "file2"),
-    #         "and",
-    #         *bash("cat", "file0", "file2", "redirect_to", "file3"),
-    #     ),
-    # ),
+    "bash-in-bash": bash_multi(
+        bash_multi(
+            ["echo", "hi", "redirect_to", "file0"],
+            ["cat", "file0", "file0", "redirect_to", "file1"],
+        ),
+        bash_multi(
+            ["cat", "file0", "file1", "redirect_to", "file2"],
+            ["cat", "file0", "file2", "redirect_to", "file3"],
+        ),
+    ),
 }
 
 


### PR DESCRIPTION
Rename `ProvLog` and `prov_log` to `ProbeLog` and `probe_log` and other simple renames.