### PR TITLE
Remove argc count

### DIFF
--- a/libprobe/generator/libc_hooks_source.c
+++ b/libprobe/generator/libc_hooks_source.c
@@ -1992,27 +1992,23 @@ char * mkdtemp (char *template) { }
 /* Need: We need this because exec kills all global variables, we need to dump our tables before continuing */
 int execv (const char *filename, char *const argv[]) {
     void* pre_call = ({
-        size_t argc = 0;
-        char * const* copied_argv = arena_copy_argv(get_data_arena(), argv, &argc);
+        char * const* copied_argv = arena_copy_argv(get_data_arena(), argv, 0);
         size_t envc = 0;
         char* const* updated_env = update_env_with_probe_vars(environ, &envc);
         /* TODO: Avoid this copy */
-        char * const* copied_updated_env = arena_copy_argv(get_data_arena(), updated_env, &envc);
+        char * const* copied_updated_env = arena_copy_argv(get_data_arena(), updated_env, envc);
         struct Op op = {
             exec_op_code,
             {.exec = {
                 .path = create_path_lazy(0, filename, 0),
                 .ferrno = 0,
-                .argc = argc,
                 .argv = copied_argv,
-                .envc = envc,
                 .env = copied_updated_env,
             }},
             {0},
             0,
             0,
         };
-        op.data.exec.argc = argc;
         if (LIKELY(prov_log_is_enabled())) {
             prov_log_try(op);
             prov_log_save();
@@ -2058,18 +2054,16 @@ int execl (const char *filename, const char *arg0, ...) {
         }
         va_end(ap);
         argv[argc] = NULL;
-        char * const* copied_argv = arena_copy_argv(get_data_arena(), argv, &argc);
+        char * const* copied_argv = arena_copy_argv(get_data_arena(), argv, argc);
         size_t envc = 0;
         char * const* updated_env = update_env_with_probe_vars(environ, &envc);
-        char * const* copied_updated_env = arena_copy_argv(get_data_arena(), updated_env, &envc);
+        char * const* copied_updated_env = arena_copy_argv(get_data_arena(), updated_env, envc);
         struct Op op = {
             exec_op_code,
             {.exec = {
                 .path = create_path_lazy(0, filename, 0),
                 .ferrno = 0,
-                .argc = argc,
                 .argv = copied_argv,
-                .envc = envc,
                 .env = copied_updated_env,
             }},
             {0},
@@ -2098,19 +2092,16 @@ int execl (const char *filename, const char *arg0, ...) {
 }
 int execve (const char *filename, char *const argv[], char *const env[]) {
     void* pre_call = ({
-        size_t argc = 0;
-        char * const* copied_argv = arena_copy_argv(get_data_arena(), argv, &argc);
+        char * const* copied_argv = arena_copy_argv(get_data_arena(), argv, 0);
         size_t envc = 0;
         char * const* updated_env = update_env_with_probe_vars(env, &envc);
-        char * const* copied_updated_env = arena_copy_argv(get_data_arena(), updated_env, &envc);
+        char * const* copied_updated_env = arena_copy_argv(get_data_arena(), updated_env, envc);
         struct Op op = {
             exec_op_code,
             {.exec = {
                 .path = create_path_lazy(0, filename, 0),
                 .ferrno = 0,
-                .argc = argc,
                 .argv = copied_argv,
-                .envc = envc,
                 .env = copied_updated_env,
             }},
             {0},
@@ -2138,19 +2129,16 @@ int execve (const char *filename, char *const argv[], char *const env[]) {
 }
 int fexecve (int fd, char *const argv[], char *const env[]) {
     void* pre_call = ({
-        size_t argc = 0;
-        char * const* copied_argv = arena_copy_argv(get_data_arena(), argv, &argc);
+        char * const* copied_argv = arena_copy_argv(get_data_arena(), argv, 0);
         size_t envc = 0;
         char * const* updated_env = update_env_with_probe_vars(env, &envc);
-        char * const* copied_updated_env = arena_copy_argv(get_data_arena(), updated_env, &envc);
+        char * const* copied_updated_env = arena_copy_argv(get_data_arena(), updated_env, 0);
         struct Op op = {
             exec_op_code,
             {.exec = {
                 .path = create_path_lazy(fd, "", AT_EMPTY_PATH),
                 .ferrno = 0,
-                .argc = argc,
                 .argv = copied_argv,
-                .envc = envc,
                 .env = copied_updated_env,
             }},
             {0},
@@ -2186,20 +2174,18 @@ int execle (const char *filename, const char *arg0, ...) {
             argv[i] = va_arg(ap, __type_charp);
         }
         argv[argc] = NULL;
-        char * const* copied_argv = arena_copy_argv(get_data_arena(), argv, &argc);
+        char * const* copied_argv = arena_copy_argv(get_data_arena(), argv, argc);
         char** env = va_arg(ap, __type_charpp);
         va_end(ap);
         size_t envc = 0;
         char * const* updated_env = update_env_with_probe_vars(env, &envc);
-        char * const* copied_updated_env = arena_copy_argv(get_data_arena(), updated_env, &envc);
+        char * const* copied_updated_env = arena_copy_argv(get_data_arena(), updated_env, envc);
         struct Op op = {
             exec_op_code,
             {.exec = {
                 .path = create_path_lazy(0, filename, 0),
                 .ferrno = 0,
-                .argc = argc,
                 .argv = copied_argv,
-                .envc = envc,
                 .env = copied_updated_env,
             }},
             {0},
@@ -2231,11 +2217,10 @@ int execvp (const char *filename, char *const argv[]) {
     void* pre_call = ({
         char* bin_path = arena_calloc(get_data_arena(), PATH_MAX + 1, sizeof(char));
         bool found = lookup_on_path(filename, bin_path);
-        size_t argc = 0;
-        char * const* copied_argv = arena_copy_argv(get_data_arena(), argv, &argc);
+        char * const* copied_argv = arena_copy_argv(get_data_arena(), argv, 0);
         size_t envc = 0;
         char * const* updated_env = update_env_with_probe_vars(environ, &envc);
-        char * const* copied_updated_env = arena_copy_argv(get_data_arena(), updated_env, &envc);
+        char * const* copied_updated_env = arena_copy_argv(get_data_arena(), updated_env, envc);
         struct Op op = {
             exec_op_code,
             {.exec = {
@@ -2244,9 +2229,7 @@ int execvp (const char *filename, char *const argv[]) {
                  * */
                 .path = found ? create_path_lazy(0, bin_path, 0) : null_path,
                 .ferrno = 0,
-                .argc = argc,
                 .argv = copied_argv,
-                .envc = envc,
                 .env = copied_updated_env,
             }},
             {0},
@@ -2285,10 +2268,10 @@ int execlp (const char *filename, const char *arg0, ...) {
         }
         argv[argc] = NULL;
         va_end(ap);
-        char * const* copied_argv = arena_copy_argv(get_data_arena(), argv, &argc);
+        char * const* copied_argv = arena_copy_argv(get_data_arena(), argv, argc);
         size_t envc = 0;
         char * const* updated_env = update_env_with_probe_vars(environ, &envc);
-        char * const* copied_updated_env = arena_copy_argv(get_data_arena(), updated_env, &envc);
+        char * const* copied_updated_env = arena_copy_argv(get_data_arena(), updated_env, envc);
         struct Op op = {
             exec_op_code,
             {.exec = {
@@ -2297,9 +2280,7 @@ int execlp (const char *filename, const char *arg0, ...) {
                  * */
                 .path = found ? create_path_lazy(0, bin_path, 0) : null_path,
                 .ferrno = 0,
-                .argc = argc,
                 .argv = copied_argv,
-                .envc = envc,
                 .env = copied_updated_env,
             }},
             {0},
@@ -2332,11 +2313,10 @@ int execvpe(const char *filename, char *const argv[], char *const envp[]) {
     void* pre_call = ({
         char* bin_path = arena_calloc(get_data_arena(), PATH_MAX + 1, sizeof(char));
         bool found = lookup_on_path(filename, bin_path);
-        size_t argc = 0;
-        char * const* copied_argv = arena_copy_argv(get_data_arena(), argv, &argc);
+        char * const* copied_argv = arena_copy_argv(get_data_arena(), argv, 0);
         size_t envc = 0;
         char * const* updated_env = update_env_with_probe_vars(envp, &envc);
-        char * const* copied_updated_env = arena_copy_argv(get_data_arena(), updated_env, &envc);
+        char * const* copied_updated_env = arena_copy_argv(get_data_arena(), updated_env, envc);
         struct Op op = {
             exec_op_code,
             {.exec = {
@@ -2345,9 +2325,7 @@ int execvpe(const char *filename, char *const argv[], char *const envp[]) {
                  * */
                 .path = found ? create_path_lazy(0, bin_path, 0) : null_path,
                 .ferrno = 0,
-                .argc = argc,
                 .argv = copied_argv,
-                .envc = envc,
                 .env = copied_updated_env,
             }},
             {0},

--- a/libprobe/include/libprobe/prov_ops.h
+++ b/libprobe/include/libprobe/prov_ops.h
@@ -66,8 +66,6 @@ struct InitExecEpochOp {
     char* program_name;
 };
 
-struct InitExecEpochOp init_current_exec_epoch();
-
 struct InitThreadOp {
     pid_t tid;
 };
@@ -95,9 +93,7 @@ struct ChdirOp {
 struct ExecOp {
     struct Path path;
     int ferrno;
-    size_t argc;
     char* const* argv;
-    size_t envc;
     char* const* env;
 };
 

--- a/libprobe/src/env.c
+++ b/libprobe/src/env.c
@@ -131,25 +131,25 @@ char* const* update_env_with_probe_vars(char* const* env, size_t* new_env_size) 
     return new_env;
 }
 
-char* const* arena_copy_argv(struct ArenaDir* arena_dir, char* const* argv, size_t* argc) {
-    if (*argc == 0) {
-        /* Compute argc and store in *argc */
+char* const* arena_copy_argv(struct ArenaDir* arena_dir, char* const* argv, size_t argc) {
+    if (argc == 0) {
+        /* Compute argc and store in argc */
         for (char* const* argv_p = argv; *argv_p; ++argv_p) {
-            (*argc)++;
+            ++argc;
         }
     }
 
-    char** argv_copy = arena_calloc(arena_dir, *argc + 1, sizeof(char*));
+    char** argv_copy = arena_calloc(arena_dir, argc + 1, sizeof(char*));
 
-    for (size_t i = 0; i < *argc; ++i) {
+    for (size_t i = 0; i < argc; ++i) {
         size_t length = strlen(argv[i]);
         argv_copy[i] = arena_calloc(arena_dir, length + 1, sizeof(char));
         memcpy(argv_copy[i], argv[i], length + 1);
         ASSERTF(!argv_copy[i][length], "");
     }
 
-    ASSERTF(!argv[*argc], "");
-    argv_copy[*argc] = NULL;
+    ASSERTF(!argv[argc], "");
+    argv_copy[argc] = NULL;
 
     return argv_copy;
 }

--- a/libprobe/src/env.h
+++ b/libprobe/src/env.h
@@ -19,5 +19,5 @@ update_env_with_probe_vars(char* const* user_env, size_t* updated_env_size)
  * If argc argument is positive, assume that is the argc.
  * */
 __attribute__((visibility("hidden"))) char* const* arena_copy_argv(struct ArenaDir* arena_dir,
-                                                                   char* const* argv, size_t* argc)
+                                                                   char* const* argv, size_t argc)
     __attribute__((nonnull, returns_nonnull));

--- a/libprobe/src/prov_buffer.c
+++ b/libprobe/src/prov_buffer.c
@@ -154,7 +154,7 @@ void prov_log_record(struct Op op) {
         }
         */
         fprintf(stderr, "'%s' ", op.data.exec.path.path);
-        for (size_t idx = 0; idx < op.data.exec.argc; ++idx) {
+        for (size_t idx = 0; op.data.exec.argv[idx]; ++idx) {
             fprintf(stderr, "'%s' ", op.data.exec.argv[idx]);
         }
         fprintf(stderr, "\n");

--- a/probe_py/probe_py/analysis.py
+++ b/probe_py/probe_py/analysis.py
@@ -108,10 +108,6 @@ def validate_provlog(
                     elif isinstance(op.data, OpenOp) and op.data.ferrno == 0:
                         opened_fds.add(op.data.fd)
                     elif isinstance(op.data, ExecOp):
-                        if len(op.data.argv) != op.data.argc:
-                            ret.append("argv vs argc mismatch")
-                        if len(op.data.env) != op.data.envc:
-                            ret.append("env vs envc mismatch")
                         if not op.data.argv:
                             ret.append("No arguments stored in exec syscall")
                     elif isinstance(op.data, CloseOp) and op.data.ferrno == 0:

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -122,7 +122,8 @@ def scratch_directory(
     completion for manual inspection. It gets cleared every re-test however.
 
     """
-    scratch_dir = scratch_directory_parent / request.node.nodeid.replace("/", "_")
+    suffix: str = request.node.nodeid.replace("/", "_")
+    scratch_dir = scratch_directory_parent / suffix
     if scratch_dir.exists():
         shutil.rmtree(scratch_dir)
     scratch_dir.mkdir()


### PR DESCRIPTION
This PR removes extraneous counts for the number of arguments and environment variables, where it is neither necessary nor helpful. At one point, we thought the Rust parser would have an easier time reading the `char**` if it knew the number of elements, but we figured out how to do that without knowing the number of elements.

The number of elements is still helpful for performance but not necessary when executing `arena_copy_argv`, but those calls are split into two cases:

- In use-cases where we _already have the number of elements on-hand_, we should pass that to `arena_copy_argv`;
- In cases where we _computed the number specifically for `arena_copy_argv`_ were eliminated. Computing it in calling code is no more efficient than computing it in `arena_copy_argv`.

In both cases, we no longer need to take the number of elements as a pointer, since we don't need to use it later on; passing-by-value will do.