### PR TITLE
Propagate ProcessTreeContext to PROBE log

### DIFF
--- a/cli-wrapper/Cargo.lock
+++ b/cli-wrapper/Cargo.lock
@@ -806,6 +806,7 @@ dependencies = [
  "cbindgen",
  "clap",
  "my-workspace-hack",
+ "serde",
 ]
 
 [[package]]
@@ -979,18 +980,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cli-wrapper/headers/Cargo.toml
+++ b/cli-wrapper/headers/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/lib.rs"
 [dependencies]
 clap = {version = "4.5.35", features = ["derive"]}
 my-workspace-hack = { version = "0.1", path = "../my-workspace-hack" }
+serde = { version = "1.0.219", features = ["derive"] }
 
 [build-dependencies]
 cbindgen = "0.28.0"

--- a/cli-wrapper/lib/src/transcribe.rs
+++ b/cli-wrapper/lib/src/transcribe.rs
@@ -32,6 +32,21 @@ pub fn parse_top_level<P1: AsRef<Path>, P2: AsRef<Path> + Sync>(
 
     let start = SystemTime::now();
 
+    let ptc = probe_headers::object_from_bytes::<probe_headers::ProcessTreeContext>(
+        fs::read(
+            in_dir
+                .as_ref()
+                .join(probe_headers::PROCESS_TREE_CONTEXT_FILE),
+        )
+        .map_err(|_| ProbeError::UnreachableCode)?,
+    );
+
+    fs::write(
+        out_dir.as_ref().join("options.json"),
+        serde_json::to_vec(&ptc).map_err(|_| ProbeError::UnreachableCode)?,
+    )
+    .map_err(|_| ProbeError::UnreachableCode)?;
+
     let pids_out_dir = out_dir.as_ref().join(probe_headers::PIDS_SUBDIR);
     fs::create_dir(&pids_out_dir).wrap_err("Failed to create pids directory")?;
 

--- a/libprobe/src/prov_buffer.c
+++ b/libprobe/src/prov_buffer.c
@@ -167,7 +167,6 @@ void prov_log_record(struct Op op) {
     if (op.op_code != readdir_op_code) {
         DEBUG("recording op: %s", str);
     }
-    DEBUG("recording op: %s", str);
     if (op.op_code == exec_op_code) {
         DEBUG("Exec:");
         /*

--- a/probe_py/probe_py/ptypes.py
+++ b/probe_py/probe_py/ptypes.py
@@ -80,6 +80,7 @@ class Inode:
 @dataclasses.dataclass(frozen=True)
 class ProbeOptions:
     copy_files: bool
+    parent_of_root: Pid
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
ProcessTreeContext is available to libprobe at interposition time. This PR propagates that information into the PROBE log as well. Information, such as copy files mode, can be passed through from the invocation of `probe record` to the downstream analyses.