### PR TITLE
Refactor copy-to-store logic

### DIFF
--- a/libprobe/src/debug_logging.h
+++ b/libprobe/src/debug_logging.h
@@ -27,6 +27,8 @@
 #define DEBUG(...)
 #endif
 
+#define WARNING(str, ...) LOG("WARNING " str " (errno=%d)", ##__VA_ARGS__, errno)
+
 #define ERROR(str, ...)                                                                            \
     ({                                                                                             \
         char* errno_str = strndup(strerror(errno), 4096);                                          \


### PR DESCRIPTION
Before this PR, we treated all ops the same.

Now we convert an op into a `struct Path` and an `enum Access` (read, write, truncate_write, etc). Then we send that information to a function that decides whether to copy to store.