### PR TITLE
Include Path in CloseOp

### DIFF
--- a/libprobe/generator/gen_libc_hooks.py
+++ b/libprobe/generator/gen_libc_hooks.py
@@ -119,7 +119,7 @@ class GccCGenerator(CGenerator):
 class FunctionalNodeVisitor(typing.Generic[_T]):
     _method_cache: None | dict[str, typing.Callable[[Node], list[_T]]] = None
 
-    def visit(self, node) -> list[_T]:
+    def visit(self, node: Node) -> list[_T]:
         """ Visit a node."""
 
         if self._method_cache is None:
@@ -128,8 +128,8 @@ class FunctionalNodeVisitor(typing.Generic[_T]):
         visitor = self._method_cache.get(node.__class__.__name__, None)
         if visitor is None:
             method = 'visit_' + node.__class__.__name__
-            visitor = getattr(self, method, self.generic_visit)  # type: ignore
-            self._method_cache[node.__class__.__name__] = visitor  # type: ignore
+            visitor = getattr(self, method, self.generic_visit)
+            self._method_cache[node.__class__.__name__] = visitor
 
         assert visitor
 

--- a/libprobe/generator/gen_libc_hooks.py
+++ b/libprobe/generator/gen_libc_hooks.py
@@ -602,6 +602,7 @@ defines = """
 #include <errno.h>                                           // for errno
 #include <fcntl.h>                                           // for AT_FDCWD, O_TMPFILE
 #include <ftw.h>                                             // for ftw, nftw
+#include <limits.h>                                          // IWYU pragma: keep for INT_MAX, PATH_MAX
 #include <linux/close_range.h>                               // for CLOSE_RANGE_CLOEXEC
 #include <pthread.h>                                         // for pthread_...
 #include <sched.h>                                           // for CLONE_TH...

--- a/libprobe/generator/gen_libc_hooks.py
+++ b/libprobe/generator/gen_libc_hooks.py
@@ -602,7 +602,7 @@ defines = """
 #include <errno.h>                                           // for errno
 #include <fcntl.h>                                           // for AT_FDCWD, O_TMPFILE
 #include <ftw.h>                                             // for ftw, nftw
-#include <limits.h>                                          // for INT_MAX, PATH_MAX
+#include <linux/close_range.h>                               // for CLOSE_RANGE_CLOEXEC
 #include <pthread.h>                                         // for pthread_...
 #include <sched.h>                                           // for CLONE_TH...
 #include <spawn.h>                                           // for posix_spawn_file_actions_t

--- a/libprobe/include/libprobe/prov_ops.h
+++ b/libprobe/include/libprobe/prov_ops.h
@@ -80,9 +80,9 @@ struct OpenOp {
 };
 
 struct CloseOp {
-    int32_t low_fd;
-    int32_t high_fd;
+    int32_t fd;
     int ferrno;
+    struct Path path;
 };
 
 struct ChdirOp {

--- a/libprobe/src/prov_buffer.c
+++ b/libprobe/src/prov_buffer.c
@@ -164,6 +164,10 @@ void prov_log_try(struct Op op) {
         maybe_copy_to_store(READ_ACCESS, &op.data.exec.path);
         break;
     }
+    case spawn_op_code: {
+        maybe_copy_to_store(READ_ACCESS, &op.data.spawn.exec.path);
+        break;
+    }
     default:
         break;
     }

--- a/libprobe/src/prov_utils.c
+++ b/libprobe/src/prov_utils.c
@@ -238,7 +238,7 @@ void op_to_human_readable(char* dest, int size, struct Op* op) {
     }
 
     if (op->op_code == close_op_code) {
-        int fd_size = CHECK_SNPRINTF(dest, size, " fd=%d", op->data.close.low_fd);
+        int fd_size = CHECK_SNPRINTF(dest, size, " fd=%d", op->data.close.fd);
         dest += fd_size;
         size -= fd_size;
     }

--- a/probe_py/probe_py/analysis.py
+++ b/probe_py/probe_py/analysis.py
@@ -289,14 +289,14 @@ def validate_hb_closes(probe_log: ProbeLog, hb_graph: HbGraph) -> list[str]:
     for node in hb_graph.nodes():
         op = get_op(probe_log, *node)
         if isinstance(op.data, CloseOp) and op.data.ferrno == 0:
-            for closed_fd in range(op.data.low_fd, op.data.high_fd + 1):
-                if closed_fd not in reserved_fds:
-                    for pred_node in networkx.dfs_preorder_nodes(reservse_hb_graph, node):
-                        pred_op = get_op(probe_log, *pred_node)
-                        if isinstance(pred_op.data, OpenOp) and pred_op.data.fd == closed_fd and op.data.ferrno == 0:
-                            break
-                    else:
-                        ret.append(f"Close of {closed_fd} in {node} is not preceeded by corresponding open")
+            closed_fd = op.data.fd
+            if closed_fd not in reserved_fds:
+                for pred_node in networkx.dfs_preorder_nodes(reservse_hb_graph, node):
+                    pred_op = get_op(probe_log, *pred_node)
+                    if isinstance(pred_op.data, OpenOp) and pred_op.data.fd == closed_fd and op.data.ferrno == 0:
+                        break
+                else:
+                    ret.append(f"Close of {closed_fd} in {node} is not preceeded by corresponding open")
     return ret
 
 
@@ -427,8 +427,7 @@ def color_hb_graph(probe_log: ProbeLog, hb_graph: HbGraph) -> None:
         elif isinstance(op.data, OpenOp):
             data["label"] += f"\n{op.data.path.path.decode()} (fd={op.data.fd})"
         elif isinstance(op.data, CloseOp):
-            fds = list(range(op.data.low_fd, op.data.high_fd + 1))
-            data["label"] += "\n" + " ".join(map(str, fds))
+            data["label"] += f"\n{op.data.fd}"
         elif isinstance(op.data, CloneOp):
             data["label"] += f"\n{TaskType(op.data.task_type).name} {op.data.task_id}"
         elif isinstance(op.data, WaitOp):

--- a/probe_py/probe_py/validators.py
+++ b/probe_py/probe_py/validators.py
@@ -129,8 +129,7 @@ def validate_opens_and_closes(probe_log: ProbeLog) -> typing.Iterator[str]:
                         opened_fds.add(op.data.fd)
                     elif isinstance(op.data, CloseOp) and op.data.ferrno == 0:
                         # Range in Python is up-to-not-including high_fd, so we add one to it.
-                        for fd in range(op.data.low_fd, op.data.high_fd + 1):
-                            closed_fds.add(fd)
+                        closed_fds.add(op.data.fd)
     reserved_fds = {0, 1, 2}
     opened_fds -= reserved_fds
     closed_fds -= reserved_fds

--- a/probe_py/tests/test_graph.py
+++ b/probe_py/tests/test_graph.py
@@ -159,7 +159,7 @@ def check_for_clone_and_open(
                         assert curr_pid in check_child_processes
                         check_child_processes.remove(curr_pid)
         elif(isinstance(curr_node_op_data,CloseOp)):
-            fd = curr_node_op_data.low_fd
+            fd = curr_node_op_data.fd
             if fd in reserved_file_descriptors:
                 continue
             if curr_node_op_data.ferrno != 0:
@@ -205,7 +205,7 @@ def match_open_and_close_fd(
             if path in paths:
                 paths.remove(path)
         elif(isinstance(curr_node_op_data,CloseOp)):
-            fd = curr_node_op_data.low_fd
+            fd = curr_node_op_data.fd
             if fd in reserved_file_descriptors:
                 continue
             if curr_node_op_data.ferrno != 0:
@@ -261,8 +261,8 @@ def check_pthread_graph(
                     # ensure the right cloned process has OpenOp for the path
                     assert process_file_map[path] == curr_node_op.pthread_id
         elif curr_node_op is not None and (isinstance(curr_node_op.data, CloseOp)):
-            fd = curr_node_op.data.low_fd
-            print("close", curr_tid, curr_node_op.pthread_id, curr_node_op.data.low_fd)
+            fd = curr_node_op.data.fd
+            print("close", curr_tid, curr_node_op.pthread_id, curr_node_op.data.fd)
             if fd in reserved_file_descriptors:
                 continue
             if curr_node_op.data.ferrno != 0:


### PR DESCRIPTION
When we close a file descriptor, we should record which path got closed. The Path struct notably includes the mod time of the file, which determines the version of the path. Including that will help us check that our analysis tracked file descriptors and versions correctly. In most cases, it is only a check, but in a few cases, it actually gives us information that we wouldn't otherwise know.