### PR TITLE
Restructure thread-local data

### DIFF
--- a/cli-wrapper/headers/src/lib.rs
+++ b/cli-wrapper/headers/src/lib.rs
@@ -46,7 +46,7 @@ pub struct ProcessTreeContext {
 
 #[repr(C)]
 pub struct ProcessContext {
-    pub epoch_no: u32,
+    pub epoch_no: u16,
     pub process_tree_path: FixedPath,
     pub pid_arena_path: FixedPath,
     pub enable_recording: bool,

--- a/cli-wrapper/lib/src/ops.rs
+++ b/cli-wrapper/lib/src/ops.rs
@@ -337,7 +337,7 @@ impl FfiFrom<C_Op> for OpInternal {
 pub struct Op {
     pub data: OpInternal,
     pub time: Timespec,
-    pub pthread_id: pthread_t,
+    pub pthread_id: u16,
     pub iso_c_thread_id: thrd_t,
 
     #[serde(serialize_with = "Op::serialize_type")]

--- a/libprobe/generator/gen_libc_hooks.py
+++ b/libprobe/generator/gen_libc_hooks.py
@@ -291,7 +291,7 @@ class ParsedFunc:
 
 
 filename = pathlib.Path("generator/libc_hooks_source.c")
-ast = pycparser.parse_file(filename, use_cpp=True, cpp_args=["-Wno-unused-command-line-argument"])
+ast = pycparser.parse_file(filename, use_cpp=True, cpp_args=["-Wno-unused-command-line-argument", "-I."])
 orig_funcs = {
     node.decl.name: ParsedFunc.from_defn(node)
     for node in ast.ext
@@ -422,10 +422,13 @@ def wrapper_func_body(func: ParsedFunc) -> typing.Sequence[Node]:
         #     ]),
         # ),
     ]
+
+    noreturn = bool(find_decl(func.stmts, "noreturn", func.name))
+
     # For some reason, Clang analyzer can suddenly prove that if execle returns, errno (call_errno) must be non-zero.
     # So this is a dead store.
     # But it can't prove that for the other execs
-    if func.name != "execle":
+    if func.name != "execle" and not noreturn:
         pre_call_stmts.insert(0, define_var(c_ast_int, "saved_errno", pycparser.c_ast.ID(name="errno")))
     post_call_stmts = []
 
@@ -436,14 +439,11 @@ def wrapper_func_body(func: ParsedFunc) -> typing.Sequence[Node]:
 
     pre_call_action = find_decl(func.stmts, "pre_call", func.name)
     if not ignore_actions and pre_call_action:
-        if isinstance(pre_call_action.init, Compound):
-            pre_call_stmts.extend(pre_call_action.init.block_items)
-        else:
-            pre_call_stmts.append(pre_call_action.init)
+        pre_call_stmts.extend(expect_type(Compound, pre_call_action.init).block_items)
 
     post_call_action = find_decl(func.stmts, "post_call", func.name)
-
-    if not ignore_actions and  post_call_action:
+    assert not noreturn or not post_call_action
+    if not ignore_actions and post_call_action:
         post_call_stmts.extend(
             expect_type(Compound, post_call_action.init).block_items,
         )
@@ -479,28 +479,37 @@ def wrapper_func_body(func: ParsedFunc) -> typing.Sequence[Node]:
     else:
         call_stmts = expect_type(Compound, call_stmts_block.init).block_items
 
-    post_call_stmts.insert(
-        0,
-        define_var(c_ast_int, "call_errno", pycparser.c_ast.ID(name="errno")),
-    )
-
-    post_call_stmts.append(
-        Assignment(
-            op="=",
-            lvalue=pycparser.c_ast.ID(name="errno"),
-            rvalue=pycparser.c_ast.TernaryOp(
-                cond=pycparser.c_ast.ID(name="call_errno"),
-                iftrue=pycparser.c_ast.ID(name="call_errno"),
-                iffalse=pycparser.c_ast.ID(name="saved_errno"),
-            ) if func.name != "execle" else pycparser.c_ast.ID(name="call_errno"),
-            # See note above regarding execle
-        ),
-    )
-
-    if not is_void(func.return_type):
+    if noreturn:
+        assert is_void(func.return_type)
         post_call_stmts.append(
-            pycparser.c_ast.Return(expr=pycparser.c_ast.ID(name="ret"))
+            pycparser.c_ast.FuncCall(
+                name=pycparser.c_ast.ID(name="__builtin_unreachable"),
+                args=pycparser.c_ast.ExprList(exprs=[]),
+            )
         )
+    else:
+        post_call_stmts.insert(
+            0,
+            define_var(c_ast_int, "call_errno", pycparser.c_ast.ID(name="errno")),
+        )
+
+        post_call_stmts.append(
+            Assignment(
+                op="=",
+                lvalue=pycparser.c_ast.ID(name="errno"),
+                rvalue=pycparser.c_ast.TernaryOp(
+                    cond=pycparser.c_ast.ID(name="call_errno"),
+                    iftrue=pycparser.c_ast.ID(name="call_errno"),
+                    iffalse=pycparser.c_ast.ID(name="saved_errno"),
+                ) if func.name != "execle" else pycparser.c_ast.ID(name="call_errno"),
+                # See note above regarding execle
+            ),
+        )
+
+        if not is_void(func.return_type):
+            post_call_stmts.append(
+                pycparser.c_ast.Return(expr=pycparser.c_ast.ID(name="ret"))
+            )
 
     return pre_call_stmts + call_stmts + post_call_stmts
 

--- a/libprobe/generator/libc_hooks_source.c
+++ b/libprobe/generator/libc_hooks_source.c
@@ -70,7 +70,7 @@ FILE * fopen (const char *filename, const char *opentype) {
     });
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled())) {
-            if (ret == NULL) {
+            if (UNLIKELY(ret == NULL)) {
                 op.data.open.ferrno = call_errno;
             } else {
                 op.data.open.fd = fileno(ret);
@@ -110,7 +110,7 @@ FILE * freopen (const char *filename, const char *opentype, FILE *stream) {
     });
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled())) {
-            if (ret == NULL) {
+            if (UNLIKELY(ret == NULL)) {
                 open_op.data.open.ferrno = call_errno;
                 close_op.data.close.ferrno = call_errno;
             } else {
@@ -328,7 +328,7 @@ int close_range (unsigned int lowfd, unsigned int maxfd, int flags) {
         struct dirent* dirp;
         DEBUG("close_range %d %d %d -> close", lowfd, maxfd, flags);
         while ((dirp = unwrapped_readdir(dp)) != NULL) {
-            if ('0' <= dirp->d_name[0] && dirp->d_name[0] <= '9') {
+            if (LIKELY('0' <= dirp->d_name[0] && dirp->d_name[0] <= '9')) {
                 unsigned int fd = (unsigned int) strtol(dirp->d_name, NULL, 10);
                 if (lowfd <= fd && fd <= maxfd) {
                     /* Use the real (not unwrapped) close, so it gets logged as a normal close */
@@ -352,7 +352,7 @@ void closefrom (int lowfd) {
         struct dirent* dirp;
         DEBUG("closefrom %d -> close", lowfd);
         while ((dirp = unwrapped_readdir(dp)) != NULL) {
-            if ('0' <= dirp->d_name[0] && dirp->d_name[0] <= '9') {
+            if (LIKELY('0' <= dirp->d_name[0] && dirp->d_name[0] <= '9')) {
                 int fd = (int) strtol(dirp->d_name, NULL, 10);
                 if (lowfd <= fd) {
                     /* Use the real (not unwrapped) close, so it gets logged as a normal close */
@@ -600,7 +600,7 @@ struct dirent * readdir (DIR *dirstream) {
     });
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled())) {
-            if (ret == NULL) {
+            if (UNLIKELY(ret == NULL)) {
                 op.data.readdir.ferrno = call_errno;
             } else {
                 /* Note: we will assume these dirents aer the same as openat(fd, ret->name);
@@ -633,7 +633,7 @@ struct dirent64 * readdir64 (DIR *dirstream) {
     });
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled())) {
-            if (ret == NULL) {
+            if (UNLIKELY(ret == NULL)) {
                 op.data.readdir.ferrno = call_errno;
             } else {
                 /* Note: we will assume these dirents aer the same as openat(fd, ret->name);
@@ -667,7 +667,7 @@ int readdir_r (DIR *dirstream, struct dirent *entry, struct dirent **result) {
     });
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled())) {
-            if (*result == NULL) {
+            if (UNLIKELY(*result == NULL)) {
                 op.data.readdir.ferrno = call_errno;
             } else {
                 /* Note: we will assume these dirents aer the same as openat(fd, ret->name);
@@ -700,7 +700,7 @@ int readdir64_r (DIR *dirstream, struct dirent64 *entry, struct dirent64 **resul
     });
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled())) {
-            if (*result == NULL) {
+            if (UNLIKELY(*result == NULL)) {
                 op.data.readdir.ferrno = call_errno;
             } else {
                 /* Note: we will assume these dirents aer the same as openat(fd, ret->name);
@@ -760,7 +760,7 @@ int scandir (const char *dir, struct dirent ***namelist, int (*selector) (const 
     });
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled())) {
-            if (ret != 0) {
+            if (UNLIKELY(ret != 0)) {
                 op.data.readdir.ferrno = call_errno;
             }
             prov_log_record(op);
@@ -817,7 +817,7 @@ int scandirat(int dirfd, const char *restrict dirp,
     });
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled())) {
-            if (ret != 0) {
+            if (UNLIKELY(ret != 0)) {
                 op.data.readdir.ferrno = call_errno;
             }
             prov_log_record(op);
@@ -874,7 +874,7 @@ int ftw (const char *filename, ftw_func func, int descriptors) {
     });
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled())) {
-            if (ret != 0) {
+            if (UNLIKELY(ret != 0)) {
                 op.data.readdir.ferrno = call_errno;
             }
             prov_log_record(op);
@@ -900,7 +900,7 @@ int nftw (const char *filename, nftw_func func, int descriptors, int flag) {
     });
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled())) {
-            if (ret != 0) {
+            if (UNLIKELY(ret != 0)) {
                 op.data.readdir.ferrno = call_errno;
             }
             prov_log_record(op);
@@ -929,7 +929,7 @@ int link (const char *oldname, const char *newname) {
     });
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled())) {
-            if (ret != 0) {
+            if (UNLIKELY(ret != 0)) {
                 op.data.hard_link.ferrno = call_errno;
             }
             prov_log_record(op);
@@ -955,7 +955,7 @@ int linkat (int oldfd, const char *oldname, int newfd, const char *newname, int 
     });
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled())) {
-            if (ret != 0) {
+            if (UNLIKELY(ret != 0)) {
                 op.data.hard_link.ferrno = call_errno;
             }
             prov_log_record(op);
@@ -984,7 +984,7 @@ int linkat (int oldfd, const char *oldname, int newfd, const char *newname, int 
 /*     }); */
 /*     void* post_call = ({ */
 /*         if (LIKELY(prov_log_is_enabled())) { */
-/*             if (ret != 0) { */
+/*             if (UNLIKELY(ret != 0)) { */
 /*                 op.data.symbolic_link.ferrno = call_errno; */
 /*             } */
 /*             prov_log_record(op); */
@@ -1012,7 +1012,7 @@ int symlinkat(const char *target, int newdirfd, const char *linkpath) {
     });
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled())) {
-            if (ret != 0) {
+            if (UNLIKELY(ret != 0)) {
                 op.data.symbolic_link.ferrno = call_errno;
             }
             prov_log_record(op);
@@ -1579,7 +1579,7 @@ int chown (const char *filename, uid_t owner, gid_t group) {
     });
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled())) {
-            if (ret != 0) {
+            if (UNLIKELY(ret != 0)) {
                 op.data.readdir.ferrno = call_errno;
             }
             prov_log_record(op);
@@ -1612,7 +1612,7 @@ int fchown (int filedes, uid_t owner, gid_t group) {
     });
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled())) {
-            if (ret != 0) {
+            if (UNLIKELY(ret != 0)) {
                 op.data.readdir.ferrno = call_errno;
             }
             prov_log_record(op);
@@ -1647,7 +1647,7 @@ int lchown(const char *pathname, uid_t owner, gid_t group) {
     });
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled())) {
-            if (ret != 0) {
+            if (UNLIKELY(ret != 0)) {
                 op.data.readdir.ferrno = call_errno;
             }
             prov_log_record(op);
@@ -1680,7 +1680,7 @@ int fchownat(int dirfd, const char *pathname, uid_t owner, gid_t group, int flag
     });
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled())) {
-            if (ret != 0) {
+            if (UNLIKELY(ret != 0)) {
                 op.data.readdir.ferrno = call_errno;
             }
             prov_log_record(op);
@@ -1713,7 +1713,7 @@ int chmod (const char *filename, mode_t mode) {
     });
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled())) {
-            if (ret != 0) {
+            if (UNLIKELY(ret != 0)) {
                 op.data.readdir.ferrno = call_errno;
             }
             prov_log_record(op);
@@ -1743,7 +1743,7 @@ int fchmod (int filedes, mode_t mode) {
     });
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled())) {
-            if (ret != 0) {
+            if (UNLIKELY(ret != 0)) {
                 op.data.readdir.ferrno = call_errno;
             }
             prov_log_record(op);
@@ -1775,7 +1775,7 @@ int fchmodat(int dirfd, const char *pathname, mode_t mode, int flags) {
     });
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled())) {
-            if (ret != 0) {
+            if (UNLIKELY(ret != 0)) {
                 op.data.readdir.ferrno = call_errno;
             }
             prov_log_record(op);
@@ -1898,7 +1898,7 @@ int utimes (const char *filename, const struct timeval tvp[2]) {
     });
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled())) {
-            if (ret != 0) {
+            if (UNLIKELY(ret != 0)) {
                 op.data.readdir.ferrno = call_errno;
             }
             prov_log_record(op);
@@ -1933,7 +1933,7 @@ int lutimes (const char *filename, const struct timeval tvp[2]) {
     });
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled())) {
-            if (ret != 0) {
+            if (UNLIKELY(ret != 0)) {
                 op.data.readdir.ferrno = call_errno;
             }
             prov_log_record(op);
@@ -1968,7 +1968,7 @@ int futimes (int fd, const struct timeval tvp[2]) {
     });
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled())) {
-            if (ret != 0) {
+            if (UNLIKELY(ret != 0)) {
                 op.data.readdir.ferrno = call_errno;
             }
             prov_log_record(op);
@@ -2017,10 +2017,8 @@ int execv (const char *filename, char *const argv[]) {
         if (LIKELY(prov_log_is_enabled())) {
             prov_log_try(op);
             prov_log_record(op);
-            prov_log_save();
-        } else {
-            prov_log_save();
         }
+        prov_log_save();
     });
     void* call = ({
         int ret = unwrapped_execvpe(filename, argv, updated_env);
@@ -2079,10 +2077,8 @@ int execl (const char *filename, const char *arg0, ...) {
         if (LIKELY(prov_log_is_enabled())) {
             prov_log_try(op);
             prov_log_record(op);
-            prov_log_save();
-        } else {
-            prov_log_save();
         }
+        prov_log_save();
     });
     void* call = ({
         int ret = unwrapped_execvpe(filename, argv, updated_env);
@@ -2118,10 +2114,8 @@ int execve (const char *filename, char *const argv[], char *const env[]) {
         if (LIKELY(prov_log_is_enabled())) {
             prov_log_try(op);
             prov_log_record(op);
-            prov_log_save();
-        } else {
-            prov_log_save();
         }
+        prov_log_save();
     });
     void* call = ({
         int ret = unwrapped_execvpe(filename, argv, updated_env);
@@ -2156,10 +2150,8 @@ int fexecve (int fd, char *const argv[], char *const env[]) {
         if (LIKELY(prov_log_is_enabled())) {
             prov_log_try(op);
             prov_log_record(op);
-            prov_log_save();
-        } else {
-            prov_log_save();
         }
+        prov_log_save();
     });
     void* call = ({
         int ret = unwrapped_fexecve(fd, argv, updated_env);
@@ -2204,10 +2196,8 @@ int execle (const char *filename, const char *arg0, ...) {
         if (LIKELY(prov_log_is_enabled())) {
             prov_log_try(op);
             prov_log_record(op);
-            prov_log_save();
-        } else {
-            prov_log_save();
         }
+        prov_log_save();
         ERROR("Not implemented; I need to figure out how to update the environment.");
     });
     void* call = ({
@@ -2257,10 +2247,8 @@ int execvp (const char *filename, char *const argv[]) {
         if (LIKELY(prov_log_is_enabled())) {
             prov_log_try(op);
             prov_log_record(op);
-            prov_log_save();
-        } else {
-            prov_log_save();
         }
+        prov_log_save();
     });
     void* call = ({
         int ret = unwrapped_execvpe(filename, argv, updated_env);
@@ -2317,10 +2305,8 @@ int execlp (const char *filename, const char *arg0, ...) {
         if (LIKELY(prov_log_is_enabled())) {
             prov_log_try(op);
             prov_log_record(op);
-            prov_log_save();
-        } else {
-            prov_log_save();
         }
+        prov_log_save();
     });
     void* call = ({
         int ret = unwrapped_execvpe(filename, argv, updated_env);
@@ -2371,10 +2357,8 @@ int execvpe(const char *filename, char *const argv[], char *const envp[]) {
         if (LIKELY(prov_log_is_enabled())) {
             prov_log_try(op);
             prov_log_record(op);
-            prov_log_save();
-        } else {
-            prov_log_save();
         }
+        prov_log_save();
     });
     void* call = ({
         int ret = unwrapped_execvpe(filename, argv, updated_env);
@@ -2521,7 +2505,8 @@ pid_t fork (void) {
                 op.data.clone.ferrno = call_errno;
                 prov_log_record(op);
             } else if (ret == 0) {
-                init_after_fork();
+                /* Success; child
+                 * init_after_fork() is called implicitly due to pthread_atfork handler. */
             } else {
                 /* Success; parent */
                 op.data.clone.task_id = ret;
@@ -2559,8 +2544,8 @@ pid_t _Fork (void) {
                 op.data.clone.ferrno = call_errno;
                 prov_log_record(op);
             } else if (ret == 0) {
-                /* Success; child */
-                init_after_fork();
+                /* Success; child
+                 * init_after_fork() is called implicitly due to pthread_atfork handler. */;
             } else {
                 /* Success; parent */
                 op.data.clone.task_id = ret;
@@ -2631,7 +2616,8 @@ pid_t vfork (void) {
                 op.data.clone.ferrno = call_errno;
                 prov_log_record(op);
             } else if (ret == 0) {
-                init_after_fork();
+                /* Success; child
+                 * init_after_fork() is called implicitly due to pthread_atfork handler. */
             } else {
                 /* Success; parent */
                 op.data.clone.task_id = ret;
@@ -2686,12 +2672,9 @@ int clone(
         };
         if (LIKELY(prov_log_is_enabled())) {
             prov_log_try(op);
-            prov_log_save();
             if ((flags & CLONE_THREAD) != (flags & CLONE_VM)) {
                 NOT_IMPLEMENTED("I conflate cloning a new thread (resulting in a process with the same PID, new TID) with sharing the memory space. If CLONE_SIGHAND is set, then Linux asserts CLONE_THREAD == CLONE_VM; If it is not set and CLONE_THREAD != CLONE_VM, by a real application, I will consider disentangling the assumptions (required to support this combination).");
             }
-        } else {
-            prov_log_save();
         }
     });
     void* call = ({
@@ -3090,7 +3073,7 @@ int pthread_join(pthread_t thread, void **pthread_return) {
         } else {
             /* Success; parent */
             struct PthreadReturnVal* pthread_return_val = uncasted_return;
-            if (pthread_return_val->type_id == PTHREAD_RETURN_VAL_TYPE_ID) {
+            if (LIKELY(pthread_return_val->type_id == PTHREAD_RETURN_VAL_TYPE_ID)) {
                 op.data.wait.task_id = pthread_return_val->pthread_id;
                 if (pthread_return) {
                     *pthread_return = pthread_return_val->inner_ret;
@@ -3102,7 +3085,7 @@ int pthread_join(pthread_t thread, void **pthread_return) {
                     *pthread_return = uncasted_return;
                 }
             }
-            if (uncasted_return == PTHREAD_CANCELED) {
+            if (UNLIKELY(uncasted_return == PTHREAD_CANCELED)) {
                 op.data.wait.cancelled = true;
             }
             if (LIKELY(prov_log_is_enabled())) {

--- a/libprobe/generator/libc_hooks_source.c
+++ b/libprobe/generator/libc_hooks_source.c
@@ -29,7 +29,7 @@ typedef void* idtype;
 typedef void* id_t;
 typedef void* siginfo_t;
 typedef int bool;
-typedef int int64_t;
+typedef long int64_t;
 struct stat;
 struct utimebuf;
 typedef void* OpCode;
@@ -3101,9 +3101,9 @@ int pthread_cancel(pthread_t thread) {
     });
 }
 
+/* TODO: Convert these to ops */
 void* mmap(void* addr, size_t length, int prot, int flags, int fd, off_t offset) {}
-/* TODO: interpose munmap. see ../src/global_state.c, ../src/arena.c */
-/* int munmap(void* addr, size_t length) { } */
+int munmap(void* addr, size_t length) { }
 
 void exit (int status) {
     void* pre_call = ({struct Op op = {

--- a/libprobe/include/libprobe/prov_ops.h
+++ b/libprobe/include/libprobe/prov_ops.h
@@ -2,7 +2,6 @@
 
 #define _GNU_SOURCE
 
-#include <pthread.h>   // IWYU pragma: keep for pthread_t
 #include <stdbool.h>   // for bool, false
 #include <stddef.h>    // for size_t, NULL
 #include <stdint.h>    // for uint32_t, int32_t, uint64_t, int64_t
@@ -123,7 +122,6 @@ struct CloneOp {
 
 struct ExitOp {
     int status;
-    bool run_atexit_handlers;
 };
 
 struct AccessOp {
@@ -202,6 +200,7 @@ struct WaitOp {
     int64_t task_id;
     int options;
     int status;
+    bool cancelled;
     int ferrno;
 };
 
@@ -339,7 +338,7 @@ struct Op {
         struct MkdirOp mkdir;
     } data;
     struct timespec time;
-    pthread_t pthread_id;
+    uint16_t pthread_id;
     thrd_t iso_c_thread_id;
 };
 

--- a/libprobe/src/arena.c
+++ b/libprobe/src/arena.c
@@ -17,9 +17,6 @@
 #include "debug_logging.h"           // for EXPECT, ASSERTF, EXPECT_NONNULL
 #include "util.h"                    // for ceil_log2, MAX
 
-/* TODO: Interpose munmap. See global_state.c, ../generator/libc_hooks_source.c */
-#define unwrapped_munmap munmap
-
 struct Arena {
     size_t instantiation;
     void* base_address;

--- a/libprobe/src/arena.c
+++ b/libprobe/src/arena.c
@@ -90,10 +90,6 @@ static inline void arena_reinstantiate(struct ArenaDir* arena_dir, size_t min_ca
     ARENA_CURRENT->capacity = capacity;
     ARENA_CURRENT->used = sizeof(struct Arena);
 
-    DEBUG("arena_calloc: instantiation=%ld, base_address=%p, used=%ld, capacity=%ld",
-          ARENA_CURRENT->instantiation, ARENA_CURRENT->base_address, ARENA_CURRENT->used,
-          ARENA_CURRENT->capacity);
-
     /* Update for next instantiation */
     arena_dir->__next_instantiation++;
 }

--- a/libprobe/src/global_state.c
+++ b/libprobe/src/global_state.c
@@ -96,7 +96,7 @@ const struct FixedPath* get_probe_dir() {
 static pid_t __pid = 0;
 static inline void init_pid(bool after_fork) {
     (void)after_fork;
-    ASSERTF(!!__pid != 0 || after_fork, "__pid=%d, after_fork=%d", __pid, after_fork);
+    ASSERTF(!!__pid !=  after_fork, "__pid=%d, after_fork=%d", __pid, after_fork);
     pid_t tmp = getpid();
     ASSERTF(!after_fork || __pid != tmp,
             "If after_fork, old __pid (%d) should not be equal to new (actual) pid (%d).", __pid,

--- a/libprobe/src/global_state.c
+++ b/libprobe/src/global_state.c
@@ -96,8 +96,10 @@ const struct FixedPath* get_probe_dir() {
 static pid_t __pid = 0;
 static inline void init_pid(bool after_fork) {
     (void)after_fork;
-    ASSERTF(!!__pid == after_fork, "PID already initialized");
-    __pid = getpid();
+    ASSERTF(__pid != 0 || !after_fork, "If __pid is 0, after_fork should be false.");
+    pid_t tmp = getpid();
+    ASSERTF(__pid == 0 || (after_fork && __pid != tmp), "If __pid is non-zero, after_fork should be 1 and __pid (%d) should not be equal to actual pid (%d).", __pid, tmp);
+    __pid = tmp;
 }
 pid_t get_pid() { return EXPECT(!= 0, __pid); }
 pid_t get_pid_safe() { return getpid(); }
@@ -155,6 +157,7 @@ static inline void init_process_context() {
     __process_context = open_and_mmap(path_buf, true, sizeof(struct ProcessContext));
     /* We increment the epoch here, so if there is an exec later on, the epoch is already incremented when they see it. */
     __process_context->epoch_no += 1;
+    DEBUG("__process_context = %p {.epoch = %d, pid_arena_path = %s}", __process_context, __process_context->epoch_no, __process_context->pid_arena_path);
 }
 void uninit_process_context() {
     DEBUG("%p", __process_context);

--- a/libprobe/src/global_state.c
+++ b/libprobe/src/global_state.c
@@ -28,37 +28,42 @@
 #include "prov_utils.h"                   // for do_init_ops
 #include "util.h"                         // for CHECK_SNPRINTF, list_dir, UNLIKELY
 
-// getpid/gettid is kind of expensive (40ns per syscall)
-// but worth it for debug case
-static const pid_t pid_initial = -1;
-static pid_t pid = pid_initial;
-pid_t get_pid() { return EXPECT(== getpid(), pid); }
-static inline void init_pid() { pid = EXPECT(!= pid_initial, getpid()); }
-pid_t get_pid_safe() {
 #ifdef NDEBUG
-    return pid;
+#define check_fixed_path(path)
 #else
-    return getpid();
+#define check_fixed_path(path)                                                                     \
+    ({                                                                                             \
+        ASSERTF((path)->len > 2, "{\"%s\", %d}", (path)->bytes, (path)->len);                      \
+        ASSERTF((path)->bytes[0] == '/', "{\"%s\", %d}", (path)->bytes, (path)->len);              \
+        ASSERTF((path)->bytes[(path)->len - 1] != '\0', "{\"%s\", %d}", (path)->bytes,             \
+                (path)->len);                                                                      \
+        ASSERTF((path)->bytes[(path)->len] == '\0', "{\"%s\", %d}", (path)->bytes, (path)->len);   \
+    })
 #endif
+
+void copy_string_to_fixed_path(struct FixedPath* path, const char* string) {
+    size_t str_len = strnlen(string, PATH_MAX);
+    memcpy(&path->bytes, string, str_len);
+    path->len = str_len;
+    check_fixed_path(path);
 }
 
-static const pid_t tid_initial = -1;
-static __thread pid_t tid = tid_initial;
-pid_t get_tid() { return EXPECT(== gettid(), tid); }
-static inline void init_tid() { tid = EXPECT(!= tid_initial, gettid()); }
-pid_t get_tid_safe() {
-#ifdef NDEBUG
-    return tid;
-#else
-    return gettid();
-#endif
-}
+// Use a macro so we get the location of the callee in the dbeug log
+#define checked_mkdir(path)                                                                        \
+    ({                                                                                             \
+        DEBUG("mkdir '%s'", path);                                                                 \
+        int mkdir_ret = unwrapped_mkdirat(AT_FDCWD, path, 0777);                                   \
+        if (mkdir_ret == -1) {                                                                     \
+            list_dir(path, 2);                                                                     \
+            ERROR("Could not mkdir directory '%s'", path);                                         \
+        }                                                                                          \
+    })
 
 static inline void* open_and_mmap(const char* path, bool writable, size_t size) {
     DEBUG("mapping path = \"%s\"; size=%ld; writable=%d", path, size, writable);
     int fd = unwrapped_openat(AT_FDCWD, path, (writable ? (O_RDWR | O_CREAT) : O_RDONLY), 0777);
     if (UNLIKELY(fd == -1)) {
-        ERROR("Could not open process_tree in parent's dir at %s", path);
+        ERROR("Could not open file at %s", path);
     }
     if (writable) {
         EXPECT(== 0, unwrapped_ftruncate(fd, size));
@@ -67,54 +72,59 @@ static inline void* open_and_mmap(const char* path, bool writable, size_t size) 
         NULL, size, (writable ? (PROT_READ | PROT_WRITE) : PROT_READ), MAP_SHARED, fd, 0));
     ASSERTF(ret != MAP_FAILED, "mmap did not succeed");
     EXPECT(== 0, unwrapped_close(fd));
-    DEBUG("ret = %p", ret);
     return ret;
 }
 
-// Use a macro so we get the location of the callee in the dbeug log
-#define checked_mkdir(path)                                                                        \
-    ({                                                                                             \
-        DEBUG("mkdir %s", path);                                                                   \
-        int mkdir_ret = unwrapped_mkdirat(AT_FDCWD, path, 0777);                                   \
-        if (mkdir_ret == -1) {                                                                     \
-            list_dir(path, 2);                                                                     \
-            ERROR("Could not mkdir directory %s", path);                                           \
-        }                                                                                          \
-    })
-
-#ifdef NDEBUG
-#define check_fixed_path(path)
-#else
-#define check_fixed_path(path)                                                                     \
-    ({                                                                                             \
-        ASSERTF(path->len > 2, "{\"%s\", %d}", path->bytes, path->len);                            \
-        ASSERTF(path->bytes[0] == '/', "{\"%s\", %d}", path->bytes, path->len);                    \
-        ASSERTF(path->bytes[path->len - 1] != '\0', "{\"%s\", %d}", path->bytes, path->len);       \
-        ASSERTF(path->bytes[path->len] == '\0', "{\"%s\", %d}", path->bytes, path->len);           \
-    })
-#endif
-
+/*
+ * The rest of these variables are set up by ELF constructor.
+ * Within one epoch, pointers are valid.
+ */
 static struct FixedPath __probe_dir = {0};
 static inline void init_probe_dir() {
+    ASSERTF(__probe_dir.bytes[0] == '\0', "__probe_dir already initialized");
     const char* __probe_private_dir_env_val = getenv_copy(PROBE_DIR_VAR);
     if (UNLIKELY(!__probe_private_dir_env_val)) {
         ERROR("env " PROBE_DIR_VAR " is not set");
     }
-    size_t probe_dir_len = strnlen(__probe_private_dir_env_val, PATH_MAX);
-    memcpy(&__probe_dir.bytes, __probe_private_dir_env_val, probe_dir_len);
-    __probe_dir.len = probe_dir_len;
-    check_fixed_path((&__probe_dir));
+    copy_string_to_fixed_path(&__probe_dir, __probe_private_dir_env_val);
 }
 const struct FixedPath* get_probe_dir() {
     check_fixed_path((&__probe_dir));
     return &__probe_dir;
 }
 
-static struct InodeTable read_inodes;
-static struct InodeTable copied_or_overwritten_inodes;
-static struct ProcessContext* __process = NULL;
-static const struct ProcessTreeContext* __process_tree = NULL;
-static inline void init_process_obj() {
+static pid_t __pid = 0;
+static inline void init_pid(bool after_fork) {
+    (void)after_fork;
+    ASSERTF(!!__pid == after_fork, "PID already initialized");
+    __pid = getpid();
+}
+pid_t get_pid() { return EXPECT(!= 0, __pid); }
+pid_t get_pid_safe() { return getpid(); }
+
+static struct InodeTable __read_inodes;
+static struct InodeTable __copied_or_overwritten_inodes;
+static inline void init_tables() {
+    ASSERTF(!inode_table_is_init(&__read_inodes), "");
+    ASSERTF(!inode_table_is_init(&__copied_or_overwritten_inodes), "");
+    inode_table_init(&__read_inodes);
+    inode_table_init(&__copied_or_overwritten_inodes);
+}
+struct InodeTable* get_read_inodes() {
+    ASSERTF(inode_table_is_init(&__read_inodes), "");
+    return &__read_inodes;
+}
+struct InodeTable* get_copied_or_overwritten_inodes() {
+    ASSERTF(inode_table_is_init(&__copied_or_overwritten_inodes), "");
+    return &__copied_or_overwritten_inodes;
+}
+
+/*
+ * Set up by CLI.
+ * Use probe_dir to find and mmap this.
+ */
+static struct ProcessTreeContext* __process_tree_context = NULL;
+static inline void init_process_tree_context() {
     const struct FixedPath* probe_dir = get_probe_dir();
     char path_buf[PATH_MAX] = {0};
     memcpy(path_buf, probe_dir->bytes, probe_dir->len);
@@ -123,94 +133,66 @@ static inline void init_process_obj() {
      * Note that sizeof("abc") already includes 1 extra for the null byte. */
     memcpy(path_buf + probe_dir->len, "/" PROCESS_TREE_CONTEXT_FILE "\0",
            (sizeof(PROCESS_TREE_CONTEXT_FILE) + 1));
-    __process_tree = open_and_mmap(path_buf, false, sizeof(struct ProcessTreeContext));
-
-    /* Set up process context */
-    CHECK_SNPRINTF(path_buf + probe_dir->len, (int)(PATH_MAX - probe_dir->len),
-                   "/" CONTEXT_SUBDIR "/%d", pid);
-    __process = open_and_mmap(path_buf, true, sizeof(struct ProcessContext));
-    if (__process->epoch_no == 0) {
-        /* mkdir process dirs */
-        CHECK_SNPRINTF(path_buf + probe_dir->len, (int)(PATH_MAX - probe_dir->len),
-                       "/" PIDS_SUBDIR "/%d", pid);
-        checked_mkdir(path_buf);
-    }
-    __process->epoch_no += 1;
-
-    /* mkdir epoch */
-    CHECK_SNPRINTF(path_buf + probe_dir->len, (int)(PATH_MAX - probe_dir->len),
-                   "/" PIDS_SUBDIR "/%d/%d", pid, __process->epoch_no - 1);
-    checked_mkdir(path_buf);
-
-    inode_table_init(&read_inodes);
-    inode_table_init(&copied_or_overwritten_inodes);
+    __process_tree_context = open_and_mmap(path_buf, false, sizeof(struct ProcessTreeContext));
 }
-static inline const struct ProcessContext* get_process() { return EXPECT_NONNULL(__process); }
-static inline const struct ProcessTreeContext* get_process_tree() {
-    ASSERTF(__process_tree != NULL, "");
-    return __process_tree;
-}
-const struct FixedPath* get_libprobe_path() { return &get_process_tree()->libprobe_path; }
-enum CopyFiles get_copy_files_mode() { return get_process_tree()->copy_files; }
-
-struct InodeTable* get_read_inodes() {
-    ASSERTF(inode_table_is_init(&read_inodes), "");
-    return &read_inodes;
-}
-struct InodeTable* get_copied_or_overwritten_inodes() {
-    ASSERTF(inode_table_is_init(&copied_or_overwritten_inodes), "");
-    return &copied_or_overwritten_inodes;
-}
-
-int get_exec_epoch_safe() {
-    if (__process) {
-        return __process->epoch_no - 1;
-    } else {
-        return -1;
-    }
-}
-int get_exec_epoch() { return get_process()->epoch_no - 1; }
-
-static __thread struct FixedPath __ops_path = {0};
-static __thread struct FixedPath __data_path = {0};
-static __thread struct ArenaDir __ops_arena = {0};
-static __thread struct ArenaDir __data_arena = {0};
-static const size_t prov_log_arena_size = 64 * 1024;
-static inline void init_log_arena() {
-    const struct ProcessContext* process = get_process();
-    const struct FixedPath* probe_dir = get_probe_dir();
-    pid_t pid = get_pid();
-    pid_t tid = get_tid();
-    __ops_path.len = CHECK_SNPRINTF(__ops_path.bytes, PATH_MAX, "%s/" PIDS_SUBDIR "/%d/%d/%d",
-                                    probe_dir->bytes, pid, process->epoch_no - 1, tid);
-    check_fixed_path((&__ops_path));
-    checked_mkdir(__ops_path.bytes);
-    __ops_path.len =
-        CHECK_SNPRINTF(__ops_path.bytes, PATH_MAX, "%s/" PIDS_SUBDIR "/%d/%d/%d/" OPS_SUBDIR "/",
-                       probe_dir->bytes, pid, process->epoch_no - 1, tid);
-    check_fixed_path((&__ops_path));
-    __data_path.len =
-        CHECK_SNPRINTF(__data_path.bytes, PATH_MAX, "%s/" PIDS_SUBDIR "/%d/%d/%d/" DATA_SUBDIR "/",
-                       probe_dir->bytes, pid, process->epoch_no - 1, tid);
-    check_fixed_path((&__data_path));
-    DEBUG("ops_path = \"%s\"", __ops_path.bytes);
-    arena_create(&__ops_arena, __ops_path.bytes, __ops_path.len, PATH_MAX, prov_log_arena_size);
-    arena_create(&__data_arena, __data_path.bytes, __data_path.len, PATH_MAX, prov_log_arena_size);
-    ASSERTF(arena_is_initialized(&__ops_arena), "");
-    ASSERTF(arena_is_initialized(&__data_arena), "");
-}
-struct ArenaDir* get_op_arena() {
-    ASSERTF(arena_is_initialized(&__ops_arena), "init_log_arena() not called");
-    return &__ops_arena;
-}
-struct ArenaDir* get_data_arena() {
-    ASSERTF(arena_is_initialized(&__data_arena), "init_log_arena() not called");
-    return &__data_arena;
+static inline const struct ProcessTreeContext* get_process_tree_context() {
+    ASSERTF(__process_tree_context != NULL, "");
+    return __process_tree_context;
 }
 
 /*
- * echo '#include <stdio.h>\n#include <unistd.h>\nint main() {printf("%ld\\n", confstr(_CS_PATH, NULL, 0)); return 0;}' | gcc -x c - && ./a.out && rm a.out
+ * Set up by CLI or previous epoch.
+ * use probe_dir and pid to find this.
  */
+static struct ProcessContext* __process_context = NULL;
+static inline void init_process_context() {
+    const struct FixedPath* probe_dir = get_probe_dir();
+    char path_buf[PATH_MAX] = {0};
+    /* Set up process context */
+    memcpy(path_buf, probe_dir->bytes, probe_dir->len);
+    CHECK_SNPRINTF(path_buf + probe_dir->len, (int)(PATH_MAX - probe_dir->len),
+                   "/" CONTEXT_SUBDIR "/%d", __pid);
+    __process_context = open_and_mmap(path_buf, true, sizeof(struct ProcessContext));
+    /* We increment the epoch here, so if there is an exec later on, the epoch is already incremented when they see it. */
+    __process_context->epoch_no += 1;
+}
+void uninit_process_context() {
+    DEBUG("%p", __process_context);
+    /* munmap(__process_context, sizeof(struct ProcessContext)); */
+}
+static inline const struct ProcessContext* get_process_context() {
+    return EXPECT_NONNULL(__process_context);
+}
+ExecEpoch get_exec_epoch() { return get_process_context()->epoch_no - 1; }
+ExecEpoch get_exec_epoch_safe() {
+    if (__process_context) {
+        return __process_context->epoch_no - 1;
+    } else {
+        return 0;
+    }
+}
+static inline bool is_first_epoch() { return get_exec_epoch() == 0; }
+const struct FixedPath* get_libprobe_path() { return &(get_process_tree_context()->libprobe_path); }
+enum CopyFiles get_copy_files_mode() { return get_process_tree_context()->copy_files; }
+
+static inline void create_epoch_dir() {
+    char path_buf[PATH_MAX] = {0};
+    const struct FixedPath* probe_dir = get_probe_dir();
+    memcpy(path_buf, probe_dir->bytes, probe_dir->len);
+
+    /* mkdir epoch */
+    if (is_first_epoch()) {
+        DEBUG("First epoch");
+        /* mkdir process dirs */
+        CHECK_SNPRINTF(path_buf + probe_dir->len, (int)(PATH_MAX - probe_dir->len),
+                       "/" PIDS_SUBDIR "/%d", __pid);
+        checked_mkdir(path_buf);
+    }
+    CHECK_SNPRINTF(path_buf + probe_dir->len, (int)(PATH_MAX - probe_dir->len),
+                   "/" PIDS_SUBDIR "/%d/%d", __pid, __process_context->epoch_no - 1);
+    checked_mkdir(path_buf);
+}
+
 static struct FixedPath __default_path;
 static inline void init_default_path() {
     __default_path.len = EXPECT(!= 0, confstr(_CS_PATH, __default_path.bytes, PATH_MAX));
@@ -219,6 +201,112 @@ const char* get_default_path() {
     ASSERTF(__default_path.bytes[0] != '\0', "");
     return __default_path.bytes;
 }
+
+static PthreadID __pthread_id_counter = 1;
+
+void free_thread_state(void* arg);
+
+static pthread_key_t __thread_state_key;
+static inline void init_thread_state_key() {
+    EXPECT(== 0, pthread_key_create(&__thread_state_key, free_thread_state));
+}
+
+struct ThreadState {
+    pid_t tid;
+    PthreadID pthread_id;
+    struct FixedPath ops_path;
+    struct FixedPath data_path;
+    struct ArenaDir ops_arena;
+    struct ArenaDir data_arena;
+};
+/* pthread_getspecific is how one should access the _current thread's_ state.
+ * (*thread_table[upper_8_bits_of_pthread_id])[[lower_8_bits_of_pthread_id]] is how one should access _another thread's_ state. */
+typedef struct ThreadState* ThreadTable1[256];
+typedef ThreadTable1* ThreadTable0[256];
+ThreadTable0 __thread_table = {NULL};
+static inline void init_tid(struct ThreadState* state) { state->tid = gettid(); }
+PthreadID increment_pthread_id() {
+    return __atomic_add_fetch(&__pthread_id_counter, 1, __ATOMIC_RELAXED);
+}
+static const size_t prov_log_arena_size = 64 * 1024;
+static inline void init_paths(struct ThreadState* state) {
+    const struct FixedPath* probe_dir = get_probe_dir();
+    pid_t pid = get_pid();
+    size_t exec_epoch = get_exec_epoch();
+    state->ops_path.len =
+        CHECK_SNPRINTF(state->ops_path.bytes, PATH_MAX, "%s/" PIDS_SUBDIR "/%d/%d/%d",
+                       probe_dir->bytes, pid, exec_epoch, state->tid);
+    check_fixed_path((&state->ops_path));
+    checked_mkdir(state->ops_path.bytes);
+
+    state->ops_path.len = CHECK_SNPRINTF(state->ops_path.bytes, PATH_MAX,
+                                         "%s/" PIDS_SUBDIR "/%d/%d/%d/" OPS_SUBDIR "/",
+                                         probe_dir->bytes, pid, exec_epoch, state->tid);
+    check_fixed_path((&state->ops_path));
+
+    state->data_path.len = CHECK_SNPRINTF(state->data_path.bytes, PATH_MAX,
+                                          "%s/" PIDS_SUBDIR "/%d/%d/%d/" DATA_SUBDIR "/",
+                                          probe_dir->bytes, pid, exec_epoch, state->tid);
+    check_fixed_path((&state->data_path));
+}
+static inline void init_arenas(struct ThreadState* state) {
+    arena_create(&state->ops_arena, state->ops_path.bytes, state->ops_path.len, PATH_MAX,
+                 prov_log_arena_size);
+    arena_create(&state->data_arena, state->data_path.bytes, state->data_path.len, PATH_MAX,
+                 prov_log_arena_size);
+    ASSERTF(arena_is_initialized(&state->ops_arena), "");
+    ASSERTF(arena_is_initialized(&state->data_arena), "");
+}
+static inline struct ThreadState* get_thread_state() {
+    return EXPECT_NONNULL(pthread_getspecific(__thread_state_key));
+}
+void free_thread_state(void* arg) {
+    struct ThreadState* state = arg;
+    /* TODO: Insert exit op */
+    arena_sync(&state->data_arena);
+    arena_sync(&state->ops_arena);
+    free(state);
+}
+static inline void init_thread_state(PthreadID pthread_id) {
+    struct ThreadState* state = EXPECT_NONNULL(malloc(sizeof(struct ThreadState)));
+    init_tid(state);
+    state->pthread_id = pthread_id;
+    init_paths(state);
+    init_arenas(state);
+    ASSERTF(pthread_getspecific(__thread_state_key) == NULL,
+            "pthread threadstate key already used");
+    EXPECT(== 0, pthread_setspecific(__thread_state_key, state));
+    uint8_t pthread_id_level0 = (state->pthread_id & 0xFF00) >> 8;
+    uint8_t pthread_id_level1 = (state->pthread_id & 0x00FF);
+    if (!__thread_table[pthread_id_level0]) {
+        __thread_table[pthread_id_level0] = EXPECT_NONNULL(malloc(sizeof(ThreadTable1)));
+    }
+    ThreadTable1* level1 = __thread_table[pthread_id_level0];
+    ASSERTF(!(*level1)[pthread_id_level1], "ThreadTable at %d (%d << 8 | %d) already occupied",
+            state->pthread_id, pthread_id_level0, pthread_id_level1);
+    (*level1)[pthread_id_level1] = state;
+}
+static inline void drop_threads_after_fork() {
+    for (PthreadID pthread_id = 0; pthread_id < __pthread_id_counter; ++pthread_id) {
+        uint8_t pthread_id_level0 = (pthread_id & 0xFF00) >> 8;
+        uint8_t pthread_id_level1 = (pthread_id & 0x00FF);
+        struct ThreadState* state = (*__thread_table[pthread_id_level0])[pthread_id_level1];
+        arena_drop_after_fork(&state->data_arena);
+        arena_drop_after_fork(&state->ops_arena);
+        free(state);
+        (*__thread_table[pthread_id_level0])[pthread_id_level1] = NULL;
+        /* We free the actual ThreadState and NULL out the dangling pointer.
+         * I guess we'll leave __thread_table[pthread_id_level0] allocated.
+         * If the parent process had N threads, that's a damn decent guess of how many threads the child will have.
+         * Consider it "pre-allocation". */
+    }
+    __pthread_id_counter = 1;
+}
+struct ArenaDir* get_op_arena() { return &(get_thread_state()->ops_arena); }
+struct ArenaDir* get_data_arena() { return &(get_thread_state()->data_arena); }
+pid_t get_tid() { return get_thread_state()->tid; }
+pid_t get_tid_safe() { return gettid(); }
+PthreadID get_pthread_id() { return get_thread_state()->pthread_id; }
 
 static inline void check_function_pointers() {
 #ifndef NDEBUG
@@ -246,12 +334,6 @@ static inline void check_function_pointers() {
     EXPECT(== 0, unwrapped_close(fd));
 #endif
 }
-
-/*******************************************************/
-
-/*
- * Aggregate functions;
- * These functions call the init_* functions above */
 
 static inline void emit_init_epoch_op() {
     static struct FixedPath cwd = {0};
@@ -301,90 +383,66 @@ static inline void emit_init_thread_op() {
     prov_log_record(init_thread_op);
 }
 
-static __thread bool thread_inited = false;
-static bool exec_epoch_inited = false;
-void ensure_thread_initted() {
-    if (UNLIKELY(!thread_inited)) {
-        if (UNLIKELY(!exec_epoch_inited)) {
-            ERROR("This exec epoch was never properly initted");
-        }
-        init_tid();
-        init_log_arena();
-        thread_inited = true;
-        emit_init_thread_op();
-    }
+bool is_thread_inited() { return !!pthread_getspecific(__thread_state_key); }
+
+bool is_proc_inited() {
+    /* On forks, the PID will be changed from the parent,
+     * "resetting" the iniialization status. */
+    return getpid() == get_pid();
 }
 
-/*
- * After a fork, the process will _appear_ to be initialized, but not be truly initialized.
- * E.g., exec_epoch will be wrong.
- * Therefore, we will reset all the things and call init again.
- */
+void init_thread(PthreadID pthread_id) {
+    ASSERTF(is_proc_inited(), "Process not inited");
+    init_thread_state(pthread_id);
+    emit_init_thread_op();
+    ASSERTF(is_thread_inited(), "Failed to init thread");
+}
+void maybe_init_thread() { ASSERTF(is_thread_inited(), "Failed to init thread"); }
+
+void save_atexit() {
+    /* It seems pthread_getspecific is not valid atexit */
+    /* prov_log_save(); */
+}
+
 void init_after_fork() {
-    pid_t real_pid = getpid();
-    if (UNLIKELY(pid != real_pid)) {
-        DEBUG("Re-initializing child process");
-        // New TID/PID to detect
-        tid = tid_initial;
-        init_tid();
-        pid = real_pid;
-
-        // Fork copies RAM; function pointers should already be initted
-        // init_function_pointers();
-        check_function_pointers();
-
-        // probe dir hasn't moved, and we already got a copy of it
-        // init_probe_dir();
-
-        // But we need to get the _current_ PID process object
-        init_process_obj();
-
-        // Default path should already be fine
-        //init_default_path();
-
-        //exec_epoch_inited = true;
-
-        EXPECT(== 0, pthread_atfork(NULL, NULL, &init_after_fork));
-
-        /*
-         * We don't know if CLONE_FILES was set.
-         * We will conservatively assume it is (NOT safe to call arena_destroy)
-         * But we assume we have a new memory space, we should clear the mem-mappings.
-         * */
-        arena_drop_after_fork(&__ops_arena);
-        arena_drop_after_fork(&__data_arena);
-
-        init_log_arena();
-        thread_inited = true;
-
-        emit_init_epoch_op();
-        emit_init_thread_op();
-    }
-}
-
-/*
- * TODO: if destructors/constructors are reliable after we statically link with Musl,
- * then we should use constructors instead of `ensure_initted`.
- * We should emit a new kind of op in the destructor.
- */
-
-__attribute__((constructor)) void constructor() {
-    DEBUG("Initializing exec epoch");
-    init_tid();
-    init_pid();
-    init_function_pointers();
     check_function_pointers();
-    init_probe_dir();
-    init_process_obj();
-    init_default_path();
-    exec_epoch_inited = true;
+    init_pid(true);
+    uninit_process_context();
+    init_process_context();
+    create_epoch_dir();
+    init_thread_state_key();
+    drop_threads_after_fork();
+    init_thread_state(0);
     EXPECT(== 0, pthread_atfork(NULL, NULL, &init_after_fork));
-    init_log_arena();
-    thread_inited = true;
+    EXPECT(== 0, atexit(&save_atexit));
+    ASSERTF(is_proc_inited(), "Failed to init proc");
+    ASSERTF(is_thread_inited(), "Failed to init thread");
     emit_init_epoch_op();
     emit_init_thread_op();
 }
 
-void prov_log_save();
+void ensure_thread_initted() {
+    ASSERTF(is_proc_inited(), "Process not initialized");
+    ASSERTF(is_thread_inited(), "Thread not initialized");
+}
 
-__attribute__((destructor)) void destructor() { prov_log_save(); }
+__attribute__((constructor)) void constructor() {
+    DEBUG("Initializing exec epoch");
+    init_function_pointers();
+    check_function_pointers();
+    init_pid(false);
+    init_probe_dir();
+    init_tables();
+    init_process_tree_context();
+    init_process_context();
+    create_epoch_dir();
+    init_default_path();
+    init_thread_state_key();
+    init_thread_state(0);
+    EXPECT(== 0, pthread_atfork(NULL, NULL, &init_after_fork));
+    EXPECT(== 0, atexit(&save_atexit));
+    ASSERTF(is_proc_inited(), "Failed to init proc");
+    ASSERTF(is_thread_inited(), "Failed to init thread");
+    emit_init_epoch_op();
+    emit_init_thread_op();
+}

--- a/libprobe/src/global_state.c
+++ b/libprobe/src/global_state.c
@@ -96,9 +96,11 @@ const struct FixedPath* get_probe_dir() {
 static pid_t __pid = 0;
 static inline void init_pid(bool after_fork) {
     (void)after_fork;
-    ASSERTF(__pid != 0 || !after_fork, "If __pid is 0, after_fork should be false.");
+    ASSERTF(!!__pid != 0 || after_fork, "__pid=%d, after_fork=%d", __pid, after_fork);
     pid_t tmp = getpid();
-    ASSERTF(__pid == 0 || (after_fork && __pid != tmp), "If __pid is non-zero, after_fork should be 1 and __pid (%d) should not be equal to actual pid (%d).", __pid, tmp);
+    ASSERTF(!after_fork || __pid != tmp,
+            "If after_fork, old __pid (%d) should not be equal to new (actual) pid (%d).", __pid,
+            tmp);
     __pid = tmp;
 }
 pid_t get_pid() { return EXPECT(!= 0, __pid); }
@@ -157,7 +159,8 @@ static inline void init_process_context() {
     __process_context = open_and_mmap(path_buf, true, sizeof(struct ProcessContext));
     /* We increment the epoch here, so if there is an exec later on, the epoch is already incremented when they see it. */
     __process_context->epoch_no += 1;
-    DEBUG("__process_context = %p {.epoch = %d, pid_arena_path = %s}", __process_context, __process_context->epoch_no, __process_context->pid_arena_path);
+    DEBUG("__process_context = %p {.epoch = %d, pid_arena_path = %s}", __process_context,
+          __process_context->epoch_no, __process_context->pid_arena_path);
 }
 void uninit_process_context() {
     DEBUG("%p", __process_context);

--- a/libprobe/src/global_state.c
+++ b/libprobe/src/global_state.c
@@ -331,8 +331,7 @@ static inline void check_function_pointers() {
     ASSERTF(unwrapped_ftruncate, "");
     ASSERTF(unwrapped_mkdirat, "");
     ASSERTF(unwrapped_mmap, "");
-    /* TODO: Interpose munmap. See arena.c, ../generator/libc_hooks_source.c */
-    /* ASSERTF(unwrapped_munmap, ""); */
+    ASSERTF(unwrapped_munmap, "");
     ASSERTF(unwrapped_openat, "");
     ASSERTF(unwrapped_statx, "");
 

--- a/libprobe/src/global_state.h
+++ b/libprobe/src/global_state.h
@@ -2,6 +2,8 @@
 
 #define _GNU_SOURCE
 
+#include <stdbool.h>   // for bool
+#include <stdint.h>    // for uint16_t
 #include <sys/types.h> // for pid_t
 
 #include "../generated/bindings.h" // for CopyFiles
@@ -23,6 +25,10 @@
  * In such case, client code should call get_$X_safe(), which will test if $X is initialized, and if not, return a sentinel value
  *
  */
+
+typedef uint16_t PthreadID;
+
+typedef uint16_t ExecEpoch;
 
 __attribute__((visibility("hidden"))) pid_t get_pid_safe();
 
@@ -46,9 +52,9 @@ __attribute__((visibility("hidden"))) struct InodeTable* get_read_inodes()
 __attribute__((visibility("hidden"))) struct InodeTable* get_copied_or_overwritten_inodes()
     __attribute__((returns_nonnull));
 
-__attribute__((visibility("hidden"))) int get_exec_epoch_safe();
+__attribute__((visibility("hidden"))) ExecEpoch get_exec_epoch_safe();
 
-__attribute__((visibility("hidden"))) int get_exec_epoch();
+__attribute__((visibility("hidden"))) ExecEpoch get_exec_epoch();
 
 __attribute__((visibility("hidden"))) struct ArenaDir* get_op_arena()
     __attribute__((returns_nonnull));
@@ -56,9 +62,17 @@ __attribute__((visibility("hidden"))) struct ArenaDir* get_op_arena()
 __attribute__((visibility("hidden"))) struct ArenaDir* get_data_arena()
     __attribute__((returns_nonnull));
 
+__attribute__((visibility("hidden"))) PthreadID get_pthread_id();
+
+__attribute__((visibility("hidden"))) PthreadID increment_pthread_id();
+
 __attribute__((visibility("hidden"))) const char* get_default_path()
     __attribute__((returns_nonnull));
 
 __attribute__((visibility("hidden"))) void ensure_thread_initted();
+
+__attribute__((visibility("hidden"))) void init_thread(PthreadID);
+
+__attribute__((visibility("hidden"))) bool is_thread_inited();
 
 __attribute__((visibility("hidden"))) void init_after_fork();

--- a/libprobe/src/prov_buffer.c
+++ b/libprobe/src/prov_buffer.c
@@ -4,7 +4,6 @@
 
 #include <fcntl.h>    // for AT_FDCWD, O_RDWR, O_CREAT
 #include <limits.h>   // IWYU pragma: keep for PATH_MAX
-#include <pthread.h>  // for pthread_self
 #include <sched.h>    // for CLONE_VFORK
 #include <stdbool.h>  // for bool, true
 #include <stdio.h>    // for fprintf, stderr
@@ -206,7 +205,7 @@ void prov_log_record(struct Op op) {
     //    EXPECT(== 0, clock_gettime(CLOCK_MONOTONIC, &op.time));
     //}
     if (op.pthread_id == 0) {
-        op.pthread_id = pthread_self();
+        op.pthread_id = get_pthread_id();
     }
     if (op.iso_c_thread_id == 0) {
         op.iso_c_thread_id = thrd_current();

--- a/libprobe/src/pthread_helper.c
+++ b/libprobe/src/pthread_helper.c
@@ -6,21 +6,36 @@
 
 #include "debug_logging.h"
 #include "global_state.h"
+#include "prov_buffer.h"
 
 void* pthread_helper(void* restrict uncasted_arg) {
     DEBUG("Intercepting new child pthread");
-    ensure_thread_initted();
     struct PthreadHelperArg* pthread_helper_arg = uncasted_arg;
-    void* ret = pthread_helper_arg->start_routine(pthread_helper_arg->arg);
+    init_thread(pthread_helper_arg->pthread_id);
+    void* inner_arg = pthread_helper_arg->arg;
+    struct PthreadReturnVal* pthread_return_val =
+        EXPECT_NONNULL(malloc(sizeof(struct PthreadReturnVal)));
+    pthread_return_val->type_id = PTHREAD_RETURN_VAL_TYPE_ID;
+    pthread_return_val->pthread_id = pthread_helper_arg->pthread_id;
+    pthread_return_val->inner_ret = pthread_helper_arg->start_routine(inner_arg);
     free(pthread_helper_arg);
-    return ret;
+    return pthread_return_val;
 }
 
 int thrd_helper(void* restrict uncasted_arg) {
     DEBUG("Intercepting new child ISO C thread");
-    ensure_thread_initted();
+    /* We don't know if this thread is a new pthread or multiplexed on an existing one.
+     * N:M threading model, where N is ISO C threads and M is pthreads.
+     * Hardware (aka kernel) vs software (aka user) threads aren't what matters here
+     * Pthread vs multiplexed-onto-pthread matters,
+     * because we use pthread_getspecific.
+     * */
+    if (!is_thread_inited()) {
+        init_thread(increment_pthread_id());
+    }
     struct ThrdHelperArg* thrd_helper_arg = uncasted_arg;
     int ret = thrd_helper_arg->func(thrd_helper_arg->arg);
     free(thrd_helper_arg);
+    prov_log_save();
     return ret;
 }

--- a/libprobe/src/pthread_helper.h
+++ b/libprobe/src/pthread_helper.h
@@ -1,17 +1,31 @@
 #pragma once
 
+#include <stdint.h>
+
 #define _GNU_SOURCE
 
 struct PthreadHelperArg {
     void* (*start_routine)(void*);
+    uint16_t pthread_id;
     void* restrict arg;
 };
 
-__attribute__((visibility("hidden"))) void* pthread_helper(void* restrict arg);
+static const uint64_t PTHREAD_RETURN_VAL_TYPE_ID = 0x9fc84cce961fbf9f;
+
+struct PthreadReturnVal {
+    /* Should be always set to PTHREAD_RETURN_VAL_TYPE_ID.
+     * This helps us know that the rest of the struct was set by us. */
+    uint64_t type_id;
+
+    uint16_t pthread_id;
+    void* inner_ret;
+};
+
+void* pthread_helper(void* restrict arg);
 
 struct ThrdHelperArg {
     int (*func)(void*);
     void* restrict arg;
 };
 
-__attribute__((visibility("hidden"))) int thrd_helper(void* restrict arg);
+int thrd_helper(void* restrict arg);

--- a/probe_py/probe_py/hb_graph.py
+++ b/probe_py/probe_py/hb_graph.py
@@ -60,7 +60,7 @@ def probe_log_to_hb_graph(probe_log: ProbeLog) -> HbGraph:
 
     _create_other_thread_edges(probe_log, hb_graph)
 
-    validate_hb_graph(hb_graph, False)
+    validate_hb_graph(hb_graph, True)
 
     return hb_graph
 
@@ -175,8 +175,29 @@ def _create_clone_edges(node: OpNode, probe_log: ProbeLog, hb_graph: HbGraph) ->
                     target = OpNode(target_pid, initial_exec_no, target_pid.main_thread(), 0)
                     assert hb_graph.has_node(target)
                     hb_graph.add_edge(node, target)
-            case _:
-                warnings.warn("Clone edges between other kinds of threads are sound but not percise for now")
+            case TaskType.TASK_PTHREAD | TaskType.TASK_ISO_C_THREAD:
+                targets = get_first_task_nodes(probe_log, node.pid, node.exec_no, op.data.task_type, op.data.task_id, False)
+                for target in targets:
+                    assert hb_graph.has_node(target)
+                    hb_graph.add_edge(node, target)
+
+
+def get_first_task_nodes(
+        probe_log: ProbeLog,
+        pid: Pid,
+        exec_no: ExecNo,
+        task_type: int,
+        task_id: int,
+        reverse: bool,
+) -> list[OpNode]:
+    targets = []
+    for tid, thread in probe_log.processes[pid].execs[exec_no].threads.items():
+        for op_no, other_op in enumerate(reversed(thread.ops) if reverse else thread.ops):
+            if (task_type == TaskType.TASK_PTHREAD and other_op.pthread_id == task_id) or \
+               (task_type == TaskType.TASK_ISO_C_THREAD and other_op.iso_c_thread_id == task_id):
+                targets.append(OpNode(pid, exec_no, tid, op_no))
+                break
+    return targets
 
 
 def _create_wait_edges(node: OpNode, probe_log: ProbeLog, hb_graph: HbGraph) -> None:
@@ -200,8 +221,11 @@ def _create_wait_edges(node: OpNode, probe_log: ProbeLog, hb_graph: HbGraph) -> 
                     target = OpNode(target_pid, last_exec_no, target_pid.main_thread(), last_op_no)
                     assert hb_graph.has_node(target)
                     hb_graph.add_edge(target, node)
-            case _:
-                warnings.warn("Wait edges between other kinds of threads are sound but not percise for now")
+            case TaskType.TASK_PTHREAD | TaskType.TASK_ISO_C_THREAD:
+                targets = get_first_task_nodes(probe_log, node.pid, node.exec_no, op.data.task_type, op.data.task_id, True)
+                for target in targets:
+                    assert hb_graph.has_node(target)
+                    hb_graph.add_edge(target, node)
 
 
 def _create_exec_edges(node: OpNode, probe_log: ProbeLog, hb_graph: HbGraph) -> None:

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -249,11 +249,11 @@ def test_downstream_analyses(
     # stdout is huge
     subprocess.run(cmd, check=True, cwd=scratch_directory, stdout=subprocess.DEVNULL)
 
-    cmd = ["probe", "export", "hb-graph", "test.png"]
+    cmd = ["probe", "export", "hb-graph", "test.dot"]
     print(shlex.join(cmd))
     subprocess.run(cmd, check=True, cwd=scratch_directory)
 
-    cmd = ["probe", "export", "dataflow-graph", "test.png"]
+    cmd = ["probe", "export", "dataflow-graph", "test.dot"]
     print(shlex.join(cmd))
     subprocess.run(cmd, check=True, cwd=scratch_directory)
 


### PR DESCRIPTION
- Create an ID for pthreads. Prior to this PR, libprobe recorded a `pthread_t` associated with the each thread (either `pthread_self()` or the argument to `pthread_join`/ `pthread_create`). The problem is that the POSIX standard specifies that the `pthread_t` struct should be compared with `pthread_equal`; non-identical struct values can represent the same thread. Therefore, this PR assigns a new thread ID whose bits identify the current thread. `prov_log_record` records the value for the current thread. `pthread_join` and `pthread_create` are modified to log the thread ID of the target.
- Use `pthread_getspecific` instead of `__thread`, which is causing problems for Musl. I also generally revamped how the global state is maintained in libprobe.