### PR TITLE
Fix glibc error

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -86,6 +86,7 @@
               pkgs.git
               (python.withPackages (pypkgs: [
                 pypkgs.pycparser
+                pypkgs.pyelftools
               ]))
             ];
             postUnpack = ''
@@ -265,6 +266,7 @@
 
                   # libprobe build time requirement
                   pypkgs.pycparser
+                  pypkgs.pyelftools
                 ]))
                 .out
 

--- a/libprobe/Makefile
+++ b/libprobe/Makefile
@@ -58,6 +58,8 @@ $(BUILD_DIR)/defined_symbols.txt: $(BUILD_DIR)/libprobe.dbg.so
 	nm --dynamic .build/libprobe.dbg.so | grep ' T ' | cut --fields=3 --delimiter=' ' > $(BUILD_DIR)/defined_symbols.txt
 
 check: compile_commands.json $(GENERATED_FILES)
+	python3 ./sorted_symbol_versions.py .build/libprobe.dbg.so | tail --lines=5
+	test GLIBC_2.34 = $(shell python3 ./sorted_symbol_versions.py .build/libprobe.dbg.so | tail --lines=1 | cut --fields=2 --delimiter=' ')
 	clang-check --analyze -extra-arg -Xanalyzer -extra-arg -analyzer-output=text $(SOURCE_FILES)
 	clang-format --dry-run --Werror $(MANUAL_SOURCE_FILES) $(MANUAL_HEADER_FILES)
 	echo $(SOURCE_FILES) $(HEADER_FILES) | xargs --max-args 1 include-what-you-use -Xiwyu --error=1

--- a/libprobe/generator/libc_hooks_source.c
+++ b/libprobe/generator/libc_hooks_source.c
@@ -329,7 +329,7 @@ int close_range (unsigned int lowfd, unsigned int maxfd, int flags) {
         DEBUG("close_range %d %d %d -> close", lowfd, maxfd, flags);
         while ((dirp = unwrapped_readdir(dp)) != NULL) {
             if (LIKELY('0' <= dirp->d_name[0] && dirp->d_name[0] <= '9')) {
-                unsigned int fd = (unsigned int) strtol(dirp->d_name, NULL, 10);
+                unsigned int fd = (unsigned int) my_atoui(dirp->d_name);
                 if (lowfd <= fd && fd <= maxfd) {
                     /* Use the real (not unwrapped) close, so it gets logged as a normal close */
                     if (flags == 0) {
@@ -353,7 +353,7 @@ void closefrom (int lowfd) {
         DEBUG("closefrom %d -> close", lowfd);
         while ((dirp = unwrapped_readdir(dp)) != NULL) {
             if (LIKELY('0' <= dirp->d_name[0] && dirp->d_name[0] <= '9')) {
-                int fd = (int) strtol(dirp->d_name, NULL, 10);
+                int fd = (int) my_atoui(dirp->d_name);
                 if (lowfd <= fd) {
                     /* Use the real (not unwrapped) close, so it gets logged as a normal close */
                     close(fd);

--- a/libprobe/sorted_symbol_versions.py
+++ b/libprobe/sorted_symbol_versions.py
@@ -1,0 +1,38 @@
+import pathlib
+import elftools.elf.elffile
+import sys
+import typing
+
+_T = typing.TypeVar("_T")
+def expect_type(typ: type[_T], data: typing.Any) -> _T:
+    if not isinstance(data, typ):
+        raise TypeError(f"Expected type {typ} for {data}")
+    return data
+
+path = sys.argv[1]
+
+symbols = []
+
+with pathlib.Path(path).open("rb") as stream:
+    elf_parsed = elftools.elf.elffile.ELFFile(stream)
+    sections = {
+        section.name: section
+        for section in elf_parsed.iter_sections()
+    }
+    for symbol_idx, symbol in enumerate(sections[".dynsym"].iter_symbols()):
+        version_idx = sections[".gnu.version"].get_symbol(symbol_idx).entry["ndx"]
+        version_pair = sections[".gnu.version_r"].get_version(version_idx)
+        if version_pair is not None:
+            version, version_aux = sections[".gnu.version_r"].get_version(version_idx)
+            lib_file_name = version.name
+            version_name, _, version_string = version_aux.name.rpartition("_")
+            try:
+                version_num = tuple(map(int, version_string.split(".")))
+            except ValueError:
+                version_num = ()
+            symbols.append((lib_file_name, version_num, version_aux.name, expect_type(str, symbol.name)))
+        else:
+            symbols.append((version_idx, (), "", symbol.name))
+
+for lib_file_name, _, version_name, symbol_name in sorted(symbols):
+    print(lib_file_name, version_name, symbol_name)

--- a/libprobe/src/util.c
+++ b/libprobe/src/util.c
@@ -187,3 +187,14 @@ char* const* read_null_delim_file(const char* path, size_t* array_len) {
 
     return array;
 }
+
+unsigned int my_atoui(const char* s) {
+    /* I reimplemented atoi because the glibc one creates a dependency on __isoc23_strtol@GLIBC_2.38
+     * and I want to support older systems.
+     * TODO: Once we statically link against musl, this can be removed */
+    unsigned int n = 0;
+    for (; '0' <= *s && *s <= '9'; ++s) {
+        n = 10 * n - (*s - '0');
+    }
+    return n;
+}

--- a/libprobe/src/util.h
+++ b/libprobe/src/util.h
@@ -95,3 +95,5 @@ __attribute__((unused)) static inline void __mark_as_used__util_h(int f, ...) {
     __attribute__((unused)) bool a = true;
     __attribute__((unused)) size_t b = 1;
 }
+
+__attribute__((visibility("hidden"))) unsigned int my_atoui(const char* s) __attribute__((nonnull));


### PR DESCRIPTION
Currently libprobe depends on symbols (functions or variables) from Glibc (until #133 is merged), such as `printf` and `dlsym`.The code for those functions is not copied into the libprobe binary, it is requested at runtime. Hopefully whoever is running PROBE has Glibc.

The compiler associates each of those symbols with a _minimum version number_, so it requests `printf@GLIBC_2.3.4`, for example. Each version of Glibc has table going from symbol name to minimum version number that is bug-compatible with the current version. Now when the code is run, it knows to request a version of `printf` at 2.3.4 or newer. The problem is that our Glibc in the dev environment is pretty new, but Glibc on the host (e.g., Ubuntu 20.04) may be older.

The long-term solution is to copy the code into libprobe (#133). In the meantime, I looked at the code and found the newest minimum version (2.38) was coming from `strtol` which is called by `atoi`, so I stopped using `atoi` in libprobe, and now the newest minimum version is 2.34 (due to `pthread_rwlock_*` and `dlsym`). I wrote a Python script to verify this doesn't silently regress in future development.