### PR TITLE
Separate cli-wrapper to its own flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
+watch_file ./cli-wrapper/flake.nix
 use_flake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,9 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up Nix
-      uses: cachix/install-nix-action@v27
+      uses: cachix/install-nix-action@v31
       with:
+        install_url: https://releases.nixos.org/nix/nix-2.30.2/install
         extra_nix_config: |
           experimental-features = nix-command flakes
 
@@ -36,7 +37,7 @@ jobs:
         echo ${{ secrets.CACHIX_AUTH_TOKEN }} | wc -c
 
     - name: Set up cachix
-      uses: cachix/cachix-action@v15
+      uses: cachix/cachix-action@v16
       with:
         name: charmonium
         authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/cli-wrapper/cli/src/main.rs
+++ b/cli-wrapper/cli/src/main.rs
@@ -173,7 +173,7 @@ fn main() -> ExitCode {
             }
         }
         Err(err) => {
-            eprintln!("{:?}", err);
+            eprintln!("{err:?}");
             ExitCode::from(PROBE_EXIT_PRINTED_ERROR)
         }
     }

--- a/cli-wrapper/flake.lock
+++ b/cli-wrapper/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1753275806,
-        "narHash": "sha256-E+Cu/AFVGwoQo4KPgcWmFS9zU7fJgXoK0o25EP3j48g=",
+        "lastModified": 1754472784,
+        "narHash": "sha256-b390kY06Sm+gzwGiaXrVzIg4mjxwt/oONlDu49260lM=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "c62e71ad8c5256ffa3cafbb1a8c687db60869e98",
+        "rev": "388a3128c3cda69c6f466de2015aadfae9f9bc75",
         "type": "github"
       },
       "original": {
@@ -16,35 +16,13 @@
         "type": "github"
       }
     },
-    "cli-wrapper": {
-      "inputs": {
-        "advisory-db": "advisory-db",
-        "crane": "crane",
-        "flake-utils": [
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "rust-overlay": "rust-overlay"
-      },
-      "locked": {
-        "path": "cli-wrapper",
-        "type": "path"
-      },
-      "original": {
-        "path": "cli-wrapper",
-        "type": "path"
-      },
-      "parent": []
-    },
     "crane": {
       "locked": {
-        "lastModified": 1753316655,
-        "narHash": "sha256-tzWa2kmTEN69OEMhxFy+J2oWSvZP5QhEgXp3TROOzl0=",
+        "lastModified": 1754269165,
+        "narHash": "sha256-0tcS8FHd4QjbCVoxN9jI+PjHgA4vc/IjkUSp+N3zy0U=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "f35a3372d070c9e9ccb63ba7ce347f0634ddf3d2",
+        "rev": "444e81206df3f7d92780680e45858e31d2f07a08",
         "type": "github"
       },
       "original": {
@@ -73,11 +51,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1754800730,
-        "narHash": "sha256-HfVZCXic9XLBgybP0318ym3cDnGwBs/+H5MgxFVYF4I=",
+        "lastModified": 1754640348,
+        "narHash": "sha256-dSSzu/afJLQIr10WRJuKucZ387YvRXmz1iABwD6SB7E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "641d909c4a7538f1539da9240dedb1755c907e40",
+        "rev": "a3f3e3f2c983e957af6b07a1db98bafd1f87b7a1",
         "type": "github"
       },
       "original": {
@@ -89,24 +67,25 @@
     },
     "root": {
       "inputs": {
-        "cli-wrapper": "cli-wrapper",
+        "advisory-db": "advisory-db",
+        "crane": "crane",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
       "inputs": {
         "nixpkgs": [
-          "cli-wrapper",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1753757591,
-        "narHash": "sha256-3okLvry8fRWZhJZP75pPC9P6U1dcu84VOCPhPLXYozI=",
+        "lastModified": 1754621349,
+        "narHash": "sha256-JkXUS/nBHyUqVTuL4EDCvUWauTHV78EYfk+WqiTAMQ4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b372cf71b4125d420d7648cbd898ab8f5c355be2",
+        "rev": "c448ab42002ac39d3337da10420c414fccfb1088",
         "type": "github"
       },
       "original": {

--- a/cli-wrapper/flake.nix
+++ b/cli-wrapper/flake.nix
@@ -1,0 +1,183 @@
+{
+  inputs = {
+    nixpkgs = {
+      url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    };
+    flake-utils = {
+      url = "github:numtide/flake-utils";
+    };
+
+    crane = {
+      url = "github:ipetkov/crane";
+    };
+
+    advisory-db = {
+      url = "github:rustsec/advisory-db";
+      flake = false;
+    };
+
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    rust-overlay,
+    crane,
+    advisory-db,
+    ...
+  } @ inputs: let
+    supported-systems = import ../targets.nix;
+  in
+    flake-utils.lib.eachSystem
+    (builtins.attrNames supported-systems)
+    (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [(import rust-overlay)];
+      };
+      rust-target = supported-systems.${system};
+      craneLib = (crane.mkLib pkgs).overrideToolchain (p:
+        p.rust-bin.stable.latest.default.override {
+          targets = [rust-target];
+        });
+    in rec {
+      # See https://crane.dev/examples/quick-start-workspace.html
+
+      src = craneLib.cleanCargoSource ./.;
+
+      lib = {inherit craneLib;};
+
+      # Common arguments can be set here to avoid repeating them later
+      commonArgs = {
+        inherit src;
+        strictDeps = true;
+
+        # all the crates in this workspace either use rust-bindgen or depend
+        # on local crate that does.
+        nativeBuildInputs = [
+          pkgs.rustPlatform.bindgenHook
+        ];
+
+        CARGO_BUILD_TARGET = rust-target;
+        CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
+        CPATH = ../libprobe/include;
+
+        # set environment variables for automatic codegen
+        preConfigurePhases = [
+          "codegenPhase"
+        ];
+        codegenPhase = ''
+          export CBINDGEN_OUTFILE="$out/resources/bindings.h"
+          export PYGEN_OUTFILE="$out/resources/ops.py"
+          mkdir --parents "$(dirname "$PYGEN_OUTFILE")"
+          echo "Sending python code to $PYGEN_OUTFILE"
+        '';
+      };
+
+      # Build *just* the cargo dependencies (of the entire workspace),
+      # so we can reuse all of that work (e.g. via cachix) when running in CI
+      # It is *highly* recommended to use something like cargo-hakari to avoid
+      # cache misses when building individual top-level-crates
+      cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+      individualCrateArgs =
+        commonArgs
+        // {
+          inherit cargoArtifacts;
+          inherit (craneLib.crateNameFromCargoToml {inherit src;}) version;
+          # disable tests since we'll run them all via cargo-nextest
+          doCheck = false;
+        };
+
+      fileSetForCrate = crates:
+        nixpkgs.lib.fileset.toSource {
+          root = ./.;
+          fileset = nixpkgs.lib.fileset.unions ([
+              ./Cargo.toml
+              ./Cargo.lock
+            ]
+            ++ (builtins.map craneLib.fileset.commonCargoSources crates));
+        };
+
+      packages = rec {
+        inherit cargoArtifacts;
+
+        # Prior to this version, the old code had one derivatino per crate (probe-cli, probe-lib, and probe-macros).
+        # What could go wrong?
+        # Since the old version used `src = ./.`, it would rebuild all three if any one changed.
+
+        # craneLib's workspace example [1] says to use `src = fileSetForCrate ./path/to/crate`.
+        # However, when I tried doing that, it would say "failed to load manifest for workspace member lib" because "failed to read macros/Cargo.toml".
+        # Because `lib/Cargo.toml` has a dependency on `{path = "../macros"}`,
+        # I think the source code of both crates have to be present at build-time of lib.
+        # Which means no source filtering is possible.
+        # Indeed the exposed packages in craneLib's example (my-cli and my-server) [1] do not depend on each other.
+        # They depend on my-common, which is *not* filtered out (*is* included) in the `src` for those crates.
+        # If it's possible to simultaneously:
+        #   - expose two Cargo crates A and B
+        #   - where A depends on B
+        #   - when A changes only A needs to be rebuilt
+        # then I don't know how to do it.
+        # Therefore, I will only offer one crate as a Nix package.
+        #
+        # https://crane.dev/examples/quick-start-workspace.html
+
+        probe-cli = craneLib.buildPackage (individualCrateArgs
+          // {
+            pname = "probe-cli";
+            cargoExtraArgs = "-p probe_cli";
+            src = fileSetForCrate [
+              ./cli
+              ./lib
+              ./macros
+              ./headers
+              ./my-workspace-hack
+            ];
+          });
+
+        default = probe-cli;
+      };
+      checks = {
+        probe-workspace-clippy = craneLib.cargoClippy (commonArgs
+          // {
+            inherit (packages) cargoArtifacts;
+            cargoClippyExtraArgs = "--all-targets -- --deny warnings";
+          });
+
+        probe-workspace-doc = craneLib.cargoDoc (commonArgs
+          // {
+            inherit (packages) cargoArtifacts;
+          });
+
+        # Check formatting
+        probe-workspace-fmt = craneLib.cargoFmt {
+          inherit src;
+        };
+
+        # Audit dependencies
+        probe-workspace-audit = craneLib.cargoAudit {
+          inherit src advisory-db;
+        };
+
+        # Audit licenses
+        probe-workspace-deny = craneLib.cargoDeny {
+          inherit src;
+        };
+
+        # Run tests with cargo-nextest
+        # this is why `doCheck = false` on the crate derivations, so as to not
+        # run the tests twice.
+        probe-workspace-nextest = craneLib.cargoNextest (commonArgs
+          // {
+            inherit (packages) cargoArtifacts;
+            partitions = 1;
+            partitionType = "count";
+          });
+      };
+    });
+}

--- a/cli-wrapper/headers/build.rs
+++ b/cli-wrapper/headers/build.rs
@@ -2,7 +2,7 @@ fn main() {
     let crate_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 
     let out_file = std::env::var_os("CBINDGEN_OUTFILE").expect("Must define CBINDGEN_OUTFILE");
-    println!("Writing C headers to $CBINDGEN_OUTFILE = {:?}", out_file);
+    println!("Writing C headers to $CBINDGEN_OUTFILE = {out_file:?}");
 
     cbindgen::Builder::new()
         .with_crate(crate_dir)

--- a/cli-wrapper/lib/build.rs
+++ b/cli-wrapper/lib/build.rs
@@ -15,7 +15,7 @@ fn find_in_cpath(name: &str) -> Result<PathBuf, String> {
         .filter(|path| path.exists())
         .collect::<Vec<_>>()
         .first()
-        .ok_or_else(|| format!("name not found; CPATH={}", cpath))?
+        .ok_or_else(|| format!("name not found; CPATH={cpath}"))?
         .clone())
 }
 
@@ -85,7 +85,7 @@ fn no_derive(name: &str) -> bool {
 impl ParseCallbacks for LibprobeCallback {
     fn item_name(&self, _original_item_name: &str) -> Option<String> {
         if should_prefix(_original_item_name) {
-            Some(format!("C_{}", _original_item_name))
+            Some(format!("C_{_original_item_name}"))
         } else {
             None
         }

--- a/cli-wrapper/macros/src/lib.rs
+++ b/cli-wrapper/macros/src/lib.rs
@@ -113,14 +113,11 @@ pub fn make_rust_op(input: TokenStream) -> TokenStream {
             let msgs = field_idents
                 .iter()
                 .map(|field_ident| {
-                    format!(
-                        "Error calling ffi_into() on {} while creating {}",
-                        field_ident, new_name
-                    )
+                    format!("Error calling ffi_into() on {field_ident} while creating {new_name}")
                 })
                 .collect::<Vec<_>>();
 
-            let serialize_type_path = format!("{}::serialize_type", new_name);
+            let serialize_type_path = format!("{new_name}::serialize_type");
             let type_name = new_name.to_string();
 
             // This is rather bad macro hygiene, but this macro is only intend for probe_frontend's

--- a/cli-wrapper/macros/src/pygen.rs
+++ b/cli-wrapper/macros/src/pygen.rs
@@ -211,12 +211,12 @@ fn convert_to_pytype(ty: &syn::Type) -> MacroResult<String> {
 
                             match name.as_str() {
                                 // a rust vec is basically a list in python
-                                "Vec" => format!("list[{}]", py_generics),
+                                "Vec" => format!("list[{py_generics}]"),
 
                                 // Any type we don't know about gets passed through verbatim.
                                 // FIXME: this is really fragile, consider throwing a compiler
                                 // error instead.
-                                _ => format!("{}[{}]", name, py_generics),
+                                _ => format!("{name}[{py_generics}]"),
                             }
                         }
                     }
@@ -243,12 +243,12 @@ pub(crate) fn pygen_write_internal(path: syn::LitStr) -> MacroResult<()> {
             .into())
         }
     };
-    println!("Writing Python module to {:?}", path_str);
+    println!("Writing Python module to {path_str:?}");
 
     let mut file = match File::create(path_str) {
         Ok(x) => x,
         Err(e) => {
-            eprintln!("pygen IO error: {}", e);
+            eprintln!("pygen IO error: {e}");
             return Err(quote_spanned! {
                 path.span() =>
                 compile_error!("Failed to create pygen file");
@@ -269,7 +269,7 @@ pub(crate) fn pygen_write_internal(path: syn::LitStr) -> MacroResult<()> {
     );
 
     if let Err(e) = writeln!(file, "{}", pygen_file().read()) {
-        eprintln!("pygen IO error: {}", e);
+        eprintln!("pygen IO error: {e}");
         return Err(quote_spanned! {
             path.span() =>
             compile_error!("Failed to write pygen file");

--- a/flake.nix
+++ b/flake.nix
@@ -213,7 +213,6 @@
               ];
               packages =
                 [
-
                   # Rust tools
                   pkgs.cargo-deny
                   pkgs.cargo-audit

--- a/flake.nix
+++ b/flake.nix
@@ -213,6 +213,13 @@
               ];
               packages =
                 [
+
+                  # Rust tools
+                  pkgs.cargo-deny
+                  pkgs.cargo-audit
+                  pkgs.cargo-machete
+                  pkgs.cargo-hakari
+
                   (python.withPackages (pypkgs: [
                     # probe_py.manual runtime requirements
                     pypkgs.networkx
@@ -222,18 +229,16 @@
                     pypkgs.sqlalchemy
                     pypkgs.xdg-base-dirs
                     pypkgs.pyyaml
-                    pypkgs.types-pyyaml
                     pypkgs.numpy
                     pypkgs.tqdm
-                    pypkgs.types-tqdm
 
                     # probe_py.manual "dev time" requirements
-                    pypkgs.psutil
+                    pypkgs.types-tqdm
+                    pypkgs.types-pyyaml
                     pypkgs.pytest
                     pypkgs.pytest-timeout
                     pypkgs.mypy
                     pypkgs.ipython
-                    pypkgs.xdg-base-dirs
 
                     # libprobe build time requirement
                     pypkgs.pycparser
@@ -253,11 +258,6 @@
                   pkgs.git
                   pkgs.include-what-you-use
                   pkgs.libclang
-
-                  # Rust tools
-                  pkgs.cargo-audit
-                  pkgs.cargo-deny
-                  pkgs.cargo-hakari
 
                   pkgs.coreutils
                   pkgs.alejandra

--- a/targets.nix
+++ b/targets.nix
@@ -1,0 +1,10 @@
+{
+  # "nix system" = "rust target";
+  "x86_64-linux" = "x86_64-unknown-linux-musl";
+  # Even with Nextflow (requires OpenJDK) removed,
+  # i686-linux still doesn't build.
+  # Only the wind and water know why. Us mere mortals never will.
+  #"i686-linux" = "i686-unknown-linux-musl";
+  "aarch64-linux" = "aarch64-unknown-linux-musl";
+  "armv7l-linux" = "armv7-unknown-linux-musleabi";
+}


### PR DESCRIPTION
PROBE CLI is built using Rust. Getting Rust from Nix is [non-trivial](https://nixos.wiki/wiki/Rust), and here we opt for [CraneLib](https://crane.dev/), so as to have fine control over the build process. However, that involves a lot of Nix code. This PR hides most of the CraneLib code in its own flake, `cli-wrapper/flake.nix`, which gets imported into the main flake in the project root.

Also, upgraded Clippy, which raised a few new auto-fixes.

Review by checking that `nix develop --command just lint` works, which calls most of the devtools that need to exist in the devshell. Also check `nix shell '.#probe' --command probe record ls`, which builds and runs PROBE (Rust CLI wrapper + C libprobe).

This PR was split off of the branch `nolibc`, as multiple smaller PRs will be easier to review.