### PR TITLE
Speed up debug text

### DIFF
--- a/probe_py/probe_py/cli.py
+++ b/probe_py/probe_py/cli.py
@@ -11,10 +11,11 @@ import tempfile
 import textwrap
 import typing
 import warnings
-import typer
 import rich.console
 import rich.pretty
 import sqlalchemy.orm
+import tqdm
+import typer
 from . import dataflow_graph as dataflow_graph_module
 from . import file_closure
 from . import graph_utils
@@ -24,6 +25,7 @@ from . import parser
 from . import ptypes
 from . import scp as scp_module
 from . import ssh_argparser
+from . import util
 from . import validators
 from .persistent_provenance_db import get_engine
 

--- a/probe_py/probe_py/ptypes.py
+++ b/probe_py/probe_py/ptypes.py
@@ -223,6 +223,14 @@ class ProbeLog:
                         parent_pid_map[Pid(op.data.child_pid)] = pid
         return parent_pid_map
 
+    def n_ops(self) -> int:
+        total = 0
+        for pid, process in sorted(self.processes.items()):
+            for epoch, exec in sorted(process.execs.items()):
+                for tid, thread in sorted(exec.threads.items()):
+                    total += len(thread.ops)
+        return total
+
 
 # TODO: implement this in probe_py.generated.ops
 class TaskType(enum.IntEnum):

--- a/probe_py/probe_py/util.py
+++ b/probe_py/probe_py/util.py
@@ -59,3 +59,25 @@ def duplicates(elements: typing.Iterable[_T]) -> typing.Iterable[_T]:
         for elem, count in collections.Counter(elements).most_common()
         if count > 1
     ]
+
+
+def decode_nested_object(
+        obj: typing.Any,
+) -> typing.Any:
+    """Converts the bytes in a nested dict to a string"""
+    if isinstance(obj, dict):
+        return {
+            decode_nested_object(key): decode_nested_object(value)
+            for key, value in obj.items()
+        }
+    elif isinstance(obj, (set, list, tuple)):
+        return [
+            decode_nested_object(elem)
+            for elem in obj
+        ]
+    elif isinstance(obj, bytes):
+        return obj.decode(errors="surrogateescape")
+    elif isinstance(obj, (str, int, float, bool, type(None))):
+        return obj
+    else:
+        raise TypeError(f"{type(obj)}: {obj}")


### PR DESCRIPTION
Speed up by avoiding slow `rich.pretty`. Instead, we use stdlib, indented JSON. It's almost as pretty and much faster.

For dozens of ops, the speed difference doesn't matter, but a PROBE log can easily contain tens of thousands, at which point, the difference is quite noticeable. Since debug-text gets called on every `test_downstream_analysis`, it speeds up the testing workflow quite a bit.