### PR TITLE
Refine op attrs

### DIFF
--- a/cli-wrapper/probe_cli/src/record.rs
+++ b/cli-wrapper/probe_cli/src/record.rs
@@ -160,6 +160,11 @@ impl Recorder {
             parent_of_root: std::process::id(),
             working_directory: probe_headers::FixedPath::from_path_ref(std::env::current_dir()?)
                 .map_err(|e| eyre!("{e:?}"))?,
+            interpose_read_writes: false, // safe fallback; libprobe should overwrite this
+            working_directory_inode: probe_headers::Inode::get_inode(".")?,
+            std_in: probe_headers::Inode::get_inode("/dev/stdin")?,
+            std_out: probe_headers::Inode::get_inode("/dev/stdout")?,
+            std_err: probe_headers::Inode::get_inode("/dev/stderr")?,
         };
         let mut ptc_mem = memory_parsing::Segments::single(
             0,

--- a/cli-wrapper/probe_cli/src/record.rs
+++ b/cli-wrapper/probe_cli/src/record.rs
@@ -160,7 +160,6 @@ impl Recorder {
             parent_of_root: std::process::id(),
             working_directory: probe_headers::FixedPath::from_path_ref(std::env::current_dir()?)
                 .map_err(|e| eyre!("{e:?}"))?,
-            interpose_read_writes: false, // safe fallback; libprobe should overwrite this
             working_directory_inode: probe_headers::Inode::get_inode(".")?,
             std_in: probe_headers::Inode::get_inode("/dev/stdin")?,
             std_out: probe_headers::Inode::get_inode("/dev/stdout")?,

--- a/cli-wrapper/probe_headers/src/context.rs
+++ b/cli-wrapper/probe_headers/src/context.rs
@@ -1,3 +1,4 @@
+use crate::ops::Inode;
 use derive_memory_parsing::MemoryParsable;
 use std::borrow::Cow;
 use std::fmt::Debug;
@@ -54,8 +55,13 @@ pub struct FixedPath {
 pub struct ProcessTreeContext {
     pub libprobe_path: FixedPath,
     pub copy_files: CopyFiles,
+    pub interpose_read_writes: bool,
     pub parent_of_root: u32,
     pub working_directory: FixedPath,
+    pub working_directory_inode: Inode,
+    pub std_in: Inode,
+    pub std_out: Inode,
+    pub std_err: Inode,
 }
 
 #[repr(C)]

--- a/cli-wrapper/probe_headers/src/context.rs
+++ b/cli-wrapper/probe_headers/src/context.rs
@@ -55,7 +55,6 @@ pub struct FixedPath {
 pub struct ProcessTreeContext {
     pub libprobe_path: FixedPath,
     pub copy_files: CopyFiles,
-    pub interpose_read_writes: bool,
     pub parent_of_root: u32,
     pub working_directory: FixedPath,
     pub working_directory_inode: Inode,

--- a/cli-wrapper/probe_headers/src/ops.rs
+++ b/cli-wrapper/probe_headers/src/ops.rs
@@ -15,27 +15,6 @@ pub struct TimeVal {
     tv_usec: SusecondsT,
 }
 
-#[derive(MemoryParsable, JsonSchema, Serialize, Debug, Clone)]
-#[repr(C)]
-pub struct Rusage {
-    ru_utime: TimeVal,
-    ru_stime: TimeVal,
-    ru_maxrss: libc::c_long,
-    ru_ixrss: libc::c_long,
-    ru_idrss: libc::c_long,
-    ru_isrss: libc::c_long,
-    ru_minflt: libc::c_long,
-    ru_majflt: libc::c_long,
-    ru_nswap: libc::c_long,
-    ru_inblock: libc::c_long,
-    ru_oublock: libc::c_long,
-    ru_msgsnd: libc::c_long,
-    ru_msgrcv: libc::c_long,
-    ru_nsignals: libc::c_long,
-    ru_nvcsw: libc::c_long,
-    ru_nivcsw: libc::c_long,
-}
-
 #[derive(MemoryParsable, JsonSchema, Serialize, Debug, PartialEq, Eq, Clone)]
 #[repr(C)]
 pub struct StatxTimestamp {
@@ -58,12 +37,40 @@ pub struct Inode {
     size: u64,
 }
 
+impl Inode {
+    pub fn get_inode(path: &str) -> eyre::Result<Inode> {
+        use eyre::WrapErr;
+        use std::os::unix::fs::MetadataExt;
+        let meta = std::fs::metadata(path).with_context(|| format!("path={}", path))?;
+        Ok(Inode {
+            device_major: TryInto::<u32>::try_into(meta.dev() >> 32)?,
+            device_minor: TryInto::<u32>::try_into(meta.dev() & 0xFFFFFFFF)?,
+            number: meta.ino(),
+            mode: TryInto::<u16>::try_into(meta.mode())?,
+            ctime: StatxTimestamp {
+                tv_sec: meta.ctime(),
+                tv_nsec: TryInto::<u32>::try_into(meta.ctime_nsec())?,
+                __padding: 0,
+            },
+            mtime: StatxTimestamp {
+                tv_sec: meta.mtime(),
+                tv_nsec: TryInto::<u32>::try_into(meta.mtime_nsec())?,
+                __padding: 0,
+            },
+            size: meta.size(),
+        })
+    }
+}
+
 // Making this be a struct helps the typing get "stronger"
 // Open Numbers can only be used where Open Numbers are expected.
 #[derive(MemoryParsable, JsonSchema, Serialize, Debug, PartialEq, Eq, Clone)]
 #[repr(C)]
 pub struct OpenNumber {
-    value: u16,
+    fd: u16,
+
+    #[serde(rename = "raw_number")]
+    number: u16,
 }
 
 /// cbindgen:prefix-with-name
@@ -83,9 +90,6 @@ pub struct InitExecEpoch {
     exe: PathArg,
     argv: StringArray,
     env: StringArray,
-    std_in: Inode,
-    std_out: Inode,
-    std_err: Inode,
 }
 
 #[derive(MemoryParsable, JsonSchema, Serialize, Debug, Clone)]
@@ -99,6 +103,7 @@ pub struct InitThread {
 pub struct Open {
     path: PathArg,
     open_number: OpenNumber,
+    fd: libc::c_int,
     inode: Inode,
     flags: libc::c_int,
     mode: libc::mode_t,
@@ -272,7 +277,9 @@ pub struct ReadLink {
 #[derive(MemoryParsable, JsonSchema, Serialize, Debug, Clone)]
 #[repr(C)]
 pub struct Dup {
-    old: OpenNumber,
+    src: OpenNumber,
+    dst: OpenNumber,
+    old_dst: OpenNumber,
     flags: libc::c_int,
 }
 

--- a/flake.nix
+++ b/flake.nix
@@ -330,7 +330,6 @@
           shellPackages =
             [
               pkgs.jq
-              pkgs.codespell
 
               # Rust tools
               pkgs.cargo-audit

--- a/flake.nix
+++ b/flake.nix
@@ -330,7 +330,6 @@
           shellPackages =
             [
               pkgs.jq
-              pkgs.codespell
 
               # Rust tools
               pkgs.cargo-audit
@@ -362,6 +361,7 @@
               pkgs.alejandra
               pkgs.just
               pkgs.ruff
+              pkgs.codespell
             ]
             # OpenJDK doesn't build on some platforms
             ++ pkgs.lib.lists.optional (system != "i686-linux" && system != "armv7l-linux") pkgs.nextflow

--- a/flake.nix
+++ b/flake.nix
@@ -330,6 +330,7 @@
           shellPackages =
             [
               pkgs.jq
+              pkgs.codespell
 
               # Rust tools
               pkgs.cargo-audit

--- a/libprobe/generator/gen_libc_hooks.py
+++ b/libprobe/generator/gen_libc_hooks.py
@@ -620,7 +620,6 @@ libc_hooks_c_preamble = """
 #include <stdint.h>                                          // for int64_t
 #include <stdio.h>                                           // for fileno
 #include <stdlib.h>                                          // for free
-#include <string.h>                                          // for memcpy
 #include <sys/resource.h>                                    // IWYU pragma: keep for rusage
 #include <sys/stat.h>                                        // for chmod, statx
 #include <sys/time.h>                                        // for futimes, timeval

--- a/libprobe/generator/libc_hooks_source.c
+++ b/libprobe/generator/libc_hooks_source.c
@@ -196,10 +196,16 @@ void closefrom (int lowfd) {
 int dup3 (int old, int new, int flags) {
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled() && ret != -1)) {
+            OpenNumber old_dst = get_open_number(new);
             prov_log_record((struct Op) {
                 .data = {
                     .dup_tag = OpData_Dup,
-                    .dup = {dup_open_numbers(old, new), 0},
+                    .dup = {
+                        .src = get_open_number(old),
+                        .old_dst = old_dst,
+                        .dst = new_open_number(new),
+                        .flags = 0,
+                    },
                 },
                 .ferrno = 0,
             });
@@ -211,10 +217,16 @@ int dup3 (int old, int new, int flags) {
 int dup (int old) {
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled() && ret != -1)) {
+            OpenNumber old_dst = get_open_number(ret);
             prov_log_record((struct Op) {
                 .data = {
                     .dup_tag = OpData_Dup,
-                    .dup = {dup_open_numbers(old, ret), 0},
+                    .dup = {
+                        .src = get_open_number(old),
+                        .old_dst = old_dst,
+                        .dst = new_open_number(ret),
+                        .flags = 0,
+                    },
                 },
                 .ferrno = 0,
             });
@@ -263,11 +275,14 @@ int fcntl (int filedes, int command, ...) {
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled())) {
             if (LIKELY(ret >= 0) && (command == F_DUPFD || command == F_DUPFD_CLOEXEC)) {
+                OpenNumber old_dst = get_open_number(ret);
                 prov_log_record((struct Op) {
                     .data = {
                         .dup_tag = OpData_Dup,
                         .dup = {
-                            .old = get_open_number(filedes),
+                            .src = get_open_number(filedes),
+                            .old_dst = old_dst,
+                            .dst = new_open_number(ret),
                             .flags = (command == F_DUPFD_CLOEXEC) ? O_CLOEXEC : 0,
                         },
                     },
@@ -283,7 +298,19 @@ fn fcntl64 = fcntl;
 int fchdir (int filedes) {
     void* post_call = ({
         if (LIKELY(prov_log_is_enabled() && ret == 0)) {
-            dup_open_numbers(filedes, AT_FDCWD);
+            OpenNumber old_dst = get_open_number(AT_FDCWD);
+            prov_log_record((struct Op) {
+                .data = {
+                    .dup_tag = OpData_Dup,
+                    .dup = {
+                        .src = get_open_number(filedes),
+                        .old_dst = old_dst,
+                        .dst = new_open_number(AT_FDCWD),
+                        .flags = 0,
+                    },
+                },
+                .ferrno = 0,
+            });
         }
     });
 }
@@ -2228,15 +2255,17 @@ int pipe2(int pipefd[2], int flags) {
     void* post_call = ({
         /* A successful pipe call is equivalent to two opens on a fifo file into specific FDs */
         if (LIKELY(ret == 0)) {
-            struct Op open_read_end_op = {
+            struct Inode inode = get_inode(pipefd[0]);
+            prov_log_record((struct Op){
                 .data = {
                     .open_tag = OpData_Open,
                     .open = {
                         .path = {
-                            .directory = new_open_number(pipefd[0]),
+                            .directory = {.fd = -99, .number = 0},
                             .name = NULL,
                         },
-                        .inode = get_inode(pipefd[0]),
+                        .open_number = new_open_number(pipefd[0]),
+                        .inode = inode,
                         .flags = O_RDONLY,
                         .mode = 0,
                         .creat = true,
@@ -2244,15 +2273,17 @@ int pipe2(int pipefd[2], int flags) {
                     },
                 },
                 .ferrno = 0,
-            };
-            struct Op open_write_end_op = {
+            });
+            prov_log_record((struct Op){
                 .data = {
                     .open_tag = OpData_Open,
                     .open = {
                         .path = {
-                            .directory = new_open_number(pipefd[1]),
+                            .directory = {.fd = -99, .number = 0},
                             .name = NULL,
                         },
+                        .open_number = new_open_number(pipefd[1]),
+                        .inode = inode,
                         .flags = O_CREAT | O_TRUNC | O_WRONLY,
                         .mode = 0,
                         .dir = false,
@@ -2260,13 +2291,10 @@ int pipe2(int pipefd[2], int flags) {
                     },
                 },
                 .ferrno = 0,
-            };
-            prov_log_record(open_read_end_op);
-            prov_log_record(open_write_end_op);
+            });
         }
     });
 }
-
 int pipe(int pipefd[2]) {
     void* call = ({
         int ret = pipe2(pipefd, 0);
@@ -2281,9 +2309,10 @@ int mkfifoat(int fd, const char* pathname, mode_t mode) {
                     .open_tag = OpData_Open,
                     .open = {
                         .path = {
-                            .directory = get_open_number(fd),
+                            .directory = {.fd=-99, .number=0},
                             .name = arena_strndup(get_data_arena(), pathname, PATH_MAX),
                         },
+                        .open_number = get_open_number(fd),
                         .inode = get_inode(ret),
                         .flags = 0,
                         .mode = mode,

--- a/libprobe/src/global_state.c
+++ b/libprobe/src/global_state.c
@@ -116,8 +116,7 @@ static inline void init_process_tree_context() {
      * Note that sizeof("abc") already includes 1 extra for the null byte. */
     probe_libc_memcpy(path_buf + probe_dir->len, "/" PROCESS_TREE_CONTEXT_FILE "\0",
                       (sizeof(PROCESS_TREE_CONTEXT_FILE) + 1));
-    __process_tree_context = open_and_mmap(path_buf, true, sizeof(struct ProcessTreeContext));
-    __process_tree_context->interpose_read_writes = INTERPOSE_READ_WRITES;
+    __process_tree_context = open_and_mmap(path_buf, false, sizeof(struct ProcessTreeContext));
 }
 static inline const struct ProcessTreeContext* _Nonnull get_process_tree_context() {
     ASSERTF(__process_tree_context != NULL, "");

--- a/libprobe/src/global_state.c
+++ b/libprobe/src/global_state.c
@@ -116,7 +116,8 @@ static inline void init_process_tree_context() {
      * Note that sizeof("abc") already includes 1 extra for the null byte. */
     probe_libc_memcpy(path_buf + probe_dir->len, "/" PROCESS_TREE_CONTEXT_FILE "\0",
                       (sizeof(PROCESS_TREE_CONTEXT_FILE) + 1));
-    __process_tree_context = open_and_mmap(path_buf, false, sizeof(struct ProcessTreeContext));
+    __process_tree_context = open_and_mmap(path_buf, true, sizeof(struct ProcessTreeContext));
+    __process_tree_context->interpose_read_writes = INTERPOSE_READ_WRITES;
 }
 static inline const struct ProcessTreeContext* _Nonnull get_process_tree_context() {
     ASSERTF(__process_tree_context != NULL, "");
@@ -352,9 +353,6 @@ static inline void emit_init_epoch_op() {
                             },
                         .argv = arena_copy_cmdline(get_data_arena(), cmdline),
                         .env = arena_copy_argv(get_data_arena(), (StringArray)probe_environ, 0),
-                        .std_in = get_inode(0),
-                        .std_out = get_inode(1),
-                        .std_err = get_inode(2),
                     },
             },
     };

--- a/libprobe/src/probe_libc.c
+++ b/libprobe/src/probe_libc.c
@@ -7,7 +7,6 @@
 #include <linux/prctl.h> // for PR_*
 #include <stddef.h>      // for size_t, NULL
 #include <stdint.h>      // for uint64_t, uintptr_t, int_fast16_t
-#include <stdio.h>       // for sprintf
 #include <stdlib.h>      // for malloc
 #include <sys/auxv.h>    // IWYU pragma: keep for AT_NULL, AT_PAGESZ
 #include <sys/syscall.h> // for SYS_dup, SYS_exit, SYS_getcwd

--- a/libprobe/src/prov_buffer.c
+++ b/libprobe/src/prov_buffer.c
@@ -176,29 +176,25 @@ struct Inode get_inode(int fd) {
 static struct FdTable fd_table;
 
 OpenNumber get_open_number(int fd) {
-    return (OpenNumber){atomic_load(fd_table_address_of_strong(&fd_table, fd))};
+    uint16_t number = atomic_load(fd_table_address_of_strong(&fd_table, fd));
+    return (OpenNumber){.fd = fd, .number = number};
 }
 
+/* Return the old open number and mark it as invalid in the future. */
 OpenNumber reset_open_number(int fd) {
-    return (OpenNumber){atomic_exchange(fd_table_address_of_strong(&fd_table, fd), 0)};
+    uint16_t number = atomic_load(fd_table_address_of_strong(&fd_table, fd));
+    DEBUG("reset_open_number: %d,%u", fd, number);
+    return (OpenNumber){.fd = fd, .number = number};
 }
-
-void set_open_number(int fd, OpenNumber open_no) {
-    atomic_store(fd_table_address_of_strong(&fd_table, fd), open_no.value);
-}
-
-OpenNumber dup_open_numbers(int old, int new) {
-    OpenNumber ret = get_open_number(old);
-    set_open_number(new, ret);
-    return ret;
-}
-
-_Atomic(uint16_t) unused_open_number = 1;
 
 OpenNumber new_open_number(int fd) {
-    OpenNumber ret = {atomic_fetch_add(&unused_open_number, 1)};
-    set_open_number(fd, ret);
-    return ret;
+    _Atomic(uint16_t)* address = fd_table_address_of_strong(&fd_table, fd);
+    uint16_t new_number = atomic_fetch_add(address, 1) + 1;
+    DEBUG("new_open_number: %d,%u", fd, new_number);
+    return (OpenNumber){
+        .fd = fd,
+        .number = new_number,
+    };
 }
 
 int open_wrapper(int dirfd, const char* filename, int flags, mode_t mode) {
@@ -355,10 +351,6 @@ FILE* fopen_wrapper(const char* filename, const char* opentype) {
 
     errno = saved_errno;
     return file;
-}
-
-OpenNumber close_wrapper(int fd) {
-    return (OpenNumber){atomic_exchange(fd_table_address_of_strong(&fd_table, fd), 0)};
 }
 
 /*

--- a/libprobe/src/prov_utils.c
+++ b/libprobe/src/prov_utils.c
@@ -113,7 +113,7 @@ void op_to_human_readable(char* dest, int size, struct Op* op) {
         break;
     }
     case OpData_Close: {
-        int fd_size = CHECK_SNPRINTF(dest, size, " fd=%d ", op->data.close.open_number.value);
+        int fd_size = CHECK_SNPRINTF(dest, size, " fd=%d ", op->data.close.open_number.fd);
         dest += fd_size;
         size -= fd_size;
         break;

--- a/probe_py/generate_headers.py
+++ b/probe_py/generate_headers.py
@@ -147,13 +147,10 @@ def add_typedefs(module: ast.mod) -> None:
                 target=ast.Name(id='AT_FDCWD'),
                 annotation=ast.Subscript(
                     value=ast.Name(id="Final"),
-                    slice=ast.Name(id="OpenNumber"),
+                    slice=ast.Name(id="int"),
                 ),
-                value=ast.Call(
-                    func=ast.Name(id="OpenNumber"),
-                    args=[ast.Constant(value=-100)],
-                    keywords=[],
-                ),
+                # cpp -E <(echo -e '#include <fcntl.h>\nAT_FDCWD') | tail --lines=1
+                value=ast.Constant(value=2**16 - 100),
                 simple=True,
             ),
         ]


### PR DESCRIPTION
- Add initial observations to `ProcessTreeContext` instead of `InitExecEpoch`
- Change `OpenNumber` to struct with FD and number.
- Write all three open-numbers in Dup ops.
- Remove `Rusage`