### PR TITLE
Fix -Wignored-attributes

### DIFF
--- a/libprobe/check_needed_syms.py
+++ b/libprobe/check_needed_syms.py
@@ -23,6 +23,7 @@ allowed = {
     "dlsym",
     "environ",
     "fileno",
+    "fprintf",
     "free",
     "malloc",
     "memcpy",
@@ -35,6 +36,7 @@ allowed = {
     "pthread_rwlock_wrlock",
     "pthread_setspecific",
     "realloc",
+    "snprintf",
     "stderr",
     "thrd_current",
 }

--- a/libprobe/generator/gen_libc_hooks.py
+++ b/libprobe/generator/gen_libc_hooks.py
@@ -528,10 +528,11 @@ libc_hooks_h_preamble = """
 #include <pthread.h>              // IWYU pragma: keep for pthread_t, pthread_attr_t
 #include <signal.h>               // for siginfo_t
 #include <spawn.h>                // for posix_spawn_file_actions_t
-#include <stdio.h>                // for L_tmpnam, FILE, size_t
 #include <sys/time.h>             // for timeval
 #include <sys/types.h>            // for pid_t, mode_t, ssize_t, gid_t, uid_t
 #include <sys/wait.h>             // IWYU pragma: keep for idtype_t
+#include "../src/libc_subset.h"   // IWYU pragma: keep for FILE
+// IWYU pragma: no_include <stdio.h> for FILE
 
 struct rusage;
 struct stat;
@@ -571,14 +572,7 @@ typedef int (*nftw_func)(const char *, const struct stat *, int, struct FTW *);
 #define __MUSL__
 #endif
 
-// Musl defines tmpnam(char*)
-// Glibc defines tmpnam(char[L_tmpnam])
-// We use tmpnam(char[L_tmpnam]) and let this macro handle the difference
-#ifdef __MUSL__
 #define __PROBE_L_tmpnam
-#elif __USE_GNU
-#define __PROBE_L_tmpnam L_tmpnam
-#endif
 
 // Musl does not define closefrom; gcc does and we interpose it.
 __attribute__((visibility("default"))) void closefrom(int lowfd);
@@ -618,25 +612,24 @@ libc_hooks_c_preamble = """
 #include <stdarg.h>                                          // for va_arg
 #include <stdbool.h>                                         // for false, true
 #include <stdint.h>                                          // for int64_t
-#include <stdio.h>                                           // for fileno
-#include <stdlib.h>                                          // for free
-#include <sys/resource.h>                                    // IWYU pragma: keep for rusage
 #include <sys/stat.h>                                        // for chmod, statx
 #include <sys/time.h>                                        // for futimes, timeval
 #include <sys/wait.h>                                        // for wait, wait3
-#include <unistd.h>                                          // for vfork, access, chdir
 #include <utime.h>                                           // for utimbuf
 // IWYU pragma: no_include "bits/statx-generic.h"               for statx
 // IWYU pragma: no_include "bits/types/siginfo_t.h"             for si_pid, si_status
-// IWYU pragma: no_include "bits/types/struct_rusage.h"         for rusage
 // IWYU pragma: no_include "linux/limits.h"                     for PATH_MAX
 // IWYU pragma: no_include "linux/stat.h"                       for statx, statx_timestamp
+// IWYU pragma: no_include <stdio.h>                            for FILE, we have libc_subset.h
+// IWYU pragma: no_include <stdlib.h>
+// IWYU pragma: no_include "unistd.h"
 
 #include "../generated/headers.h"                            // for Op, OpCode
 #include "../src/arena.h"                                    // for prov_log...
 #include "../src/debug_logging.h"                            // for DEBUG
 #include "../src/env.h"                                      // for arena_co...
 #include "../src/global_state.h"                             // for ensure_i...
+#include "../src/libc_subset.h"                              // IWYU pragma: keep for fileno
 #include "../src/lookup_on_path.h"                           // for lookup_o...
 #include "../src/probe_libc.h"                               // for probe_libc_...
 #include "../src/prov_buffer.h"                              // for prov_log...
@@ -691,7 +684,6 @@ typedef void* __type_voidp;
 _Static_assert(sizeof(struct StatxTimestamp) == sizeof(struct statx_timestamp), "");
 _Static_assert(sizeof(struct TimeVal) == sizeof(struct timeval), "");
 
-#pragma clang diagnostic ignored "-Wignored-attributes"
 """
 
 (generated / "libc_hooks.c").write_text(

--- a/libprobe/src/arena.c
+++ b/libprobe/src/arena.c
@@ -4,14 +4,14 @@
 #include <stdbool.h>  // for bool, false, true
 #include <stddef.h>   // for size_t, NULL
 #include <stdint.h>   // for uintptr_t
-#include <stdio.h>    // for snprintf
 #include <stdlib.h>   // for free, malloc
 #include <sys/mman.h> // IWYU pragma: keep for MAP_FAILED, MS_SYNC, MAP_SHARED, PROT_READ
 // IWYU pragma: no_include "bits/mman-linux.h"          for MS_SYNC, MAP_SHARED, PROT_READ
 
 #include "../generated/headers.h"
 #include "debug_logging.h" // for EXPECT, ASSERTF, EXPECT_NONNULL
-#include "probe_libc.h"    // for probe_libc_...
+#include "libc_subset.h"
+#include "probe_libc.h" // for probe_libc_...
 
 #define MAX(a, b) ((a) < (b) ? (b) : (a))
 

--- a/libprobe/src/debug_logging.h
+++ b/libprobe/src/debug_logging.h
@@ -3,10 +3,10 @@
 #define _GNU_SOURCE
 
 #include <errno.h> // for errno
-#include <stdio.h> // for fprintf, stderr
 
 #include "global_state.h" // for get_exec_epoch_safe, get_pid_safe, get_tid...
 #include "probe_libc.h"   // IWYU pragma: keep for exit_with_backup
+#include "libc_subset.h"
 
 #ifndef SOURCE_VERSION
 #define SOURCE_VERSION ""

--- a/libprobe/src/libc_subset.h
+++ b/libprobe/src/libc_subset.h
@@ -1,0 +1,21 @@
+/*
+ * We can't #include <stdio.h> in libc_hoks.c because that would give,
+ *
+ *    generated/libc_hooks.c:1740:16: error: attribute declaration must precede definition [-Werror,-Wignored-attributes]
+ *     1740 | __attribute__((visibility("default"))) size_t fread(void * restrict ptr, size_t size, size_t n, FILE * restrict stream)
+ *          |                ^
+ *    /nix/store/b3pqkywjwzqpq4vi5yffncdbywwpbrmk-glibc-2.33-117-dev/include/bits/stdio2.h:291:1: note: previous definition is here
+ *      291 | fread (void *__restrict __ptr, size_t __size, size_t __n,
+ *
+ * I also can't include anything that includes <stdio.h> and a couple of other libraries.
+ *
+ * Therefore, this library re-exports the non-overridden parts of stdio.h
+ */
+struct _IO_FILE;
+typedef struct _IO_FILE FILE;
+int fprintf(FILE* restrict, const char* restrict, ...);
+extern FILE* stderr;
+int snprintf(char* restrict, unsigned long, const char* restrict, ...);
+int fileno(FILE*);
+void free(void*);
+void* malloc(unsigned long);

--- a/libprobe/src/prov_buffer.c
+++ b/libprobe/src/prov_buffer.c
@@ -20,9 +20,9 @@
 #include "debug_logging.h"            // for DEBUG, ERROR, ASSERTF
 #include "errno.h"                    // for errno
 #include "global_state.h"             // for get_data_arena, get_op_arena
+#include "libc_subset.h"              // for fileno
 #include "linux/stat.h"               // for statx, STATX_CTIME, STATX_INO
 #include "probe_libc.h"               // for probe_copy_file, probe_libc_fa...
-#include "stdio.h"                    // for fileno
 #include "util.h"                     // for BORROWED, CHECK_SNPRINTF
 
 void prov_log_save() {

--- a/libprobe/src/prov_buffer.h
+++ b/libprobe/src/prov_buffer.h
@@ -2,8 +2,9 @@
 
 #include "../generated/headers.h" // for OpenNumber
 #include <stdbool.h>              // for bool
-#include <stdio.h>                // for FILE*
 #include <sys/types.h>            // for mode_t
+#include "libc_subset.h"          // IWYU pragma: keep for FILE
+// IWYU pragma: no_include <stdio.h>
 
 __attribute__((visibility("hidden"))) void prov_log_save();
 

--- a/libprobe/src/prov_utils.c
+++ b/libprobe/src/prov_utils.c
@@ -3,11 +3,9 @@
 #include <fcntl.h>         // for O_CREAT, AT_FDCWD, O_RDWR
 #include <limits.h>        // IWYU pragma: keep for PATH_MAX
 #include <stdbool.h>       // for bool, true, false
-#include <sys/resource.h>  // IWYU pragma: keep for rusage
 #include <sys/stat.h>      // IWYU pragma: keep for stat, statx, statx_timestamp
 #include <sys/sysmacros.h> // for major, minor
 #include <time.h>          // for timespec
-// IWYU pragma: no_include "bits/types/struct_rusage.h"      for rusage, rusage::(anonymous)
 // IWYU pragma: no_include "linux/limits.h"                  for PATH_MAX
 // IWYU pragma: no_include "linux/stat.h"                    for statx, statx_timestamp
 

--- a/libprobe/src/util.h
+++ b/libprobe/src/util.h
@@ -4,10 +4,10 @@
 
 // https://stackoverflow.com/a/78062291/1078199
 #include <stdarg.h>    // for va_arg, va_end, va_start, va_list
+#include <stddef.h>    // for size_t
 #include <stdbool.h>   // for bool
-#include <stdio.h>     // for snprintf, size_t
 #include <sys/types.h> // for ssize_t
-
+#include "libc_subset.h"
 #include "debug_logging.h" // for ASSERTF
 
 /*


### PR DESCRIPTION
`generated/libc_hooks.c` is compiled with `-fvisibility=hidden`, so we need to add `__attribute__((visibility("default")))` to function signature, but that attribute conflicts with prior definition of these symbols in libc headers. So we exclude libc headers (only for `<stdio.h>` and headers that include `<stdio.h>`)

They used to verify that the function argument types are the same as those defined in the header, but we will give this up.

We our own version of `stdio.h` and headers that include `stdio.h` called `libc_subset.h`. `libc_subset.h` only contains function prototypes. This is not the same as `probe_libc.c,h` which actually implement libc functions under a different name.