### PR TITLE
Interpose FDs passed through UNIX sockets

### DIFF
--- a/libprobe/generator/gen_libc_hooks.py
+++ b/libprobe/generator/gen_libc_hooks.py
@@ -564,6 +564,7 @@ struct stat;
 struct statx;
 struct timeval;
 struct utimbuf;
+struct msghdr;
 
 // IWYU pragma: no_include "bits/pthreadtypes.h" for pthread_t
 // IWYU pragma: no_include "bits/types/idtype_t.h" for idtype_t
@@ -635,6 +636,8 @@ libc_hooks_c_preamble = """
 #include <stdarg.h>                                          // for va_arg
 #include <stdbool.h>                                         // for false, true
 #include <stdint.h>                                          // for int64_t
+#include <string.h>
+#include <sys/socket.h>
 #include <sys/stat.h>                                        // for chmod, statx
 #include <sys/time.h>                                        // for futimes, timeval
 #include <sys/wait.h>                                        // for wait, wait3
@@ -646,6 +649,7 @@ libc_hooks_c_preamble = """
 // IWYU pragma: no_include <stdio.h>                            for FILE, we have libc_subset.h
 // IWYU pragma: no_include <stdlib.h>
 // IWYU pragma: no_include "unistd.h"
+// IWYU pragma: no_include "asm-generic/socket.h"               for SOL_SOCKET, already included in sys/socket.h
 
 #include "../generated/headers.h"                            // for Op, OpCode
 #include "../src/arena.h"                                    // for prov_log...

--- a/libprobe/generator/libc_hooks_source.c
+++ b/libprobe/generator/libc_hooks_source.c
@@ -2538,6 +2538,49 @@ ssize_t sendfile(int out_fd, int in_fd, off_t* offset, size_t count) {
 }
 
 /*
+** TODO: Track IPC.
+**
+** This is just going to help identify file descriptions passed over sockets
+ */
+ssize_t recvmsg(int socket, struct msghdr* message, int flags) {
+    void* post_call = ({
+        struct cmsghdr *control_message;
+        for (control_message = CMSG_FIRSTHDR(message); control_message != NULL; control_message = CMSG_NXTHDR(message, control_message)) {
+            if (control_message->cmsg_level == SOL_SOCKET && control_message->cmsg_type == SCM_RIGHTS) {
+                int received_fd;
+                memcpy(&received_fd, CMSG_DATA(control_message), sizeof(received_fd));
+                print_open_fd(received_fd);
+                OpenNumber new_on = new_open_number(received_fd);
+                char proc_path[64];
+                char fd_path[PATH_MAX];
+                snprintf(proc_path, sizeof(proc_path), "/proc/self/fd/%d", received_fd);
+                ssize_t len = client_readlink(proc_path, fd_path, sizeof(fd_path) - 1);
+                fd_path[len] = '\0';
+                int flags = client_fcntl(received_fd, F_GETFD);
+                prov_log_record((struct Op) {
+                    .data = {
+                        .open_tag = OpData_Open,
+                        .open = {
+                            .path = {
+                                .directory = get_open_number(AT_FDCWD),
+                                .name = arena_strndup(get_data_arena(), fd_path, PATH_MAX),
+                            },
+                            .open_number = new_on,
+                            .fd = received_fd,
+                            .flags = flags,
+                            .mode = 0,
+                            .creat = false,
+                            .dir = false,
+                        },
+                    },
+                    .ferrno = 0,
+                });
+            }
+        }
+    });
+}
+
+/*
 TODO:
 
 mmap, mmap64, munmap, shm_open, shm_unlink, memfd_create

--- a/probe_py/probe_py/dataflow_graph.py
+++ b/probe_py/probe_py/dataflow_graph.py
@@ -327,11 +327,14 @@ class Analysis:
                 case headers.Close():
                     oni = open_numbers[data.open_number.fd].get(data.open_number.number)
                     if oni is None:
-                        warnings.warn(
-                            ptypes.UnusualProbeLog(
-                                f"Close of unknown open number quad={quad}, on={data.open_number}, data={data}"
-                            )
-                        )
+                        pass
+                        # Some objects like eventpolls are associated with FDs in a manner we don't track for performance reasons
+                        # These will cause "close of unknown open number", and do not represent an error.
+                        # warnings.warn(
+                        #     ptypes.UnusualProbeLog(
+                        #         f"Close of unknown open number quad={quad}, on={data.open_number}, data={data}"
+                        #     )
+                        # )
                     else:
                         if self.probe_log.process_tree_context.interpose_read_writes:
                             downgraded_access = oni.open_mode.downgrade(


### PR DESCRIPTION
File descriptions can be sent over a UNIX socket. See [example](https://man7.org/tlpi/code/online/dist/sockets/scm_rights_send.c.html). PROBE needs to interpose this so it can have an overview of all FDs assigned to files.