### PR TITLE
Add --fix-random to PROBE

### DIFF
--- a/cli-wrapper/probe_cli/src/main.rs
+++ b/cli-wrapper/probe_cli/src/main.rs
@@ -30,6 +30,9 @@ fn inner_main() -> Result<ExitStatus> {
                     arg!(-f --overwrite "Overwrite existing output if it exists.")
                         .required(false)
                         .value_parser(value_parser!(bool)),
+                    arg!(-r --"fix-random" "Fix the value of /dev/u?random.")
+                        .required(false)
+                        .value_parser(value_parser!(bool)),
                     arg!(-n --"no-transcribe" "Emit PROBE record rather than PROBE log.")
                         .required(false)
                         .value_parser(value_parser!(bool)),
@@ -81,6 +84,7 @@ fn inner_main() -> Result<ExitStatus> {
             let no_transcribe = sub.get_flag("no-transcribe");
             let gdb = sub.get_flag("gdb");
             let debug = sub.get_flag("debug");
+            let fix_random = sub.get_flag("fix-random");
             let copy_files = sub
                 .get_one::<probe_headers::CopyFiles>("copy-files")
                 .cloned()
@@ -92,9 +96,13 @@ fn inner_main() -> Result<ExitStatus> {
                 .collect::<Vec<_>>();
 
             if no_transcribe {
-                record::record_no_transcribe(output, overwrite, gdb, debug, copy_files, cmd)
+                record::record_no_transcribe(
+                    output, overwrite, gdb, debug, copy_files, cmd, fix_random,
+                )
             } else {
-                record::record_transcribe(output, overwrite, gdb, debug, copy_files, cmd)
+                record::record_transcribe(
+                    output, overwrite, gdb, debug, copy_files, cmd, fix_random,
+                )
             }
             .wrap_err("Record command failed")
         }

--- a/cli-wrapper/probe_cli/src/record.rs
+++ b/cli-wrapper/probe_cli/src/record.rs
@@ -23,6 +23,7 @@ pub fn record_no_transcribe(
     debug: bool,
     copy_files: probe_headers::CopyFiles,
     cmd: Vec<OsString>,
+    fix_random: bool,
 ) -> Result<ExitStatus> {
     let output = match output {
         Some(x) => x,
@@ -43,6 +44,7 @@ pub fn record_no_transcribe(
         .gdb(gdb)
         .debug(debug)
         .copy_files(copy_files)
+        .fix_random(fix_random)
         .record()
         .wrap_err("Recorder::record")?;
 
@@ -63,6 +65,7 @@ pub fn record_transcribe(
     debug: bool,
     copy_files: probe_headers::CopyFiles,
     cmd: Vec<OsString>,
+    fix_random: bool,
 ) -> Result<ExitStatus> {
     let output = match output {
         Some(x) => x,
@@ -87,6 +90,7 @@ pub fn record_transcribe(
         .gdb(gdb)
         .debug(debug)
         .copy_files(copy_files)
+        .fix_random(fix_random)
         .record()?;
 
     match transcribe::transcribe_to_tar(&record_dir, &mut tar) {
@@ -110,6 +114,7 @@ pub struct Recorder {
     debug: bool,
     copy_files: probe_headers::CopyFiles,
     cmd: Vec<OsString>,
+    fix_random: bool,
 }
 
 impl Recorder {
@@ -165,6 +170,7 @@ impl Recorder {
             std_in: probe_headers::Inode::get_inode("/dev/stdin")?,
             std_out: probe_headers::Inode::get_inode("/dev/stdout")?,
             std_err: probe_headers::Inode::get_inode("/dev/stderr")?,
+            fix_random: self.fix_random,
         };
         let mut ptc_mem = memory_parsing::Segments::single(
             0,
@@ -177,6 +183,18 @@ impl Recorder {
             .path()
             .join(probe_headers::PROCESS_TREE_CONTEXT_FILE);
         std::fs::write(ptc_file, ptc_bytes)?;
+
+        if self.fix_random {
+            let personality_ret = unsafe { libc::personality(0xffffffff) };
+            if personality_ret == -1 {
+                panic!("Could not get personality");
+            }
+            let persona = personality_ret as libc::c_ulong;
+            let new_persona = persona | (libc::ADDR_NO_RANDOMIZE as u64);
+            if unsafe { libc::personality(new_persona) } == -1 {
+                panic!("Could not set personality");
+            }
+        }
 
         let mut child = if self.gdb {
             std::process::Command::new("gdb")
@@ -266,6 +284,7 @@ impl Recorder {
             debug: false,
             cmd,
             copy_files: probe_headers::CopyFiles::Lazily,
+            fix_random: false,
         }
     }
 
@@ -283,6 +302,11 @@ impl Recorder {
 
     pub fn copy_files(mut self, copy_files: probe_headers::CopyFiles) -> Self {
         self.copy_files = copy_files;
+        self
+    }
+
+    pub fn fix_random(mut self, fix_random: bool) -> Self {
+        self.fix_random = fix_random;
         self
     }
 }

--- a/cli-wrapper/probe_headers/src/context.rs
+++ b/cli-wrapper/probe_headers/src/context.rs
@@ -62,6 +62,7 @@ pub struct ProcessTreeContext {
     pub std_in: Inode,
     pub std_out: Inode,
     pub std_err: Inode,
+    pub fix_random: bool,
 }
 
 #[repr(C)]

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -13,3 +13,9 @@ TODO: We have more atomics than necessary. If we assume no races between open an
 TODO: Delete `call_errno`/`save_errno` handling. If a libc function returns a non-error return, the value of `errno` is undefined, so we don't have to set it. If we return an error, we just have to be sure that we don't call any `client_` functions that may set `errno`.
 
 TODO: Test the performance impact of interpose read/writes.
+
+Delete print_open_fd
+
+Look in to is_rand
+
+Compare syscalls with stat with/without PROBE

--- a/libprobe/check_hooked_fns.py
+++ b/libprobe/check_hooked_fns.py
@@ -6,5 +6,5 @@ import sys
 for file in sys.argv[1:]:
     for line_no, line in enumerate(pathlib.Path(file).read_text().strip().splitlines()):
         for fn in pathlib.Path("generated/libc_fns.csv").read_text().strip().splitlines():
-            if matchy := re.search("\b" + fn + "\b", line):
+            if matchy := re.search(r"\b" + fn + r"\b", line):
                 print(f"(Hooked) {fn} found at {file}:{line_no + 1}")

--- a/libprobe/generator/gen_libc_hooks.py
+++ b/libprobe/generator/gen_libc_hooks.py
@@ -562,6 +562,7 @@ struct rusage;
 struct sigevent;
 struct stat;
 struct statx;
+struct timespec;
 struct timeval;
 struct utimbuf;
 struct msghdr;
@@ -641,6 +642,7 @@ libc_hooks_c_preamble = """
 #include <sys/stat.h>                                        // for chmod, statx
 #include <sys/time.h>                                        // for futimes, timeval
 #include <sys/wait.h>                                        // for wait, wait3
+#include <time.h>                                            // for timespec, clock, clock_gettime
 #include <utime.h>                                           // for utimbuf
 // IWYU pragma: no_include "bits/statx-generic.h"               for statx
 // IWYU pragma: no_include "bits/types/siginfo_t.h"             for si_pid, si_status

--- a/libprobe/generator/libc_hooks_source.c
+++ b/libprobe/generator/libc_hooks_source.c
@@ -2521,7 +2521,7 @@ size_t fread(void* restrict ptr, size_t size, size_t n, FILE* restrict stream) {
             memset(ptr, 0, n);
             ret = n;
         } else {
-            ret = fread(ptr, size, n, stream);
+            ret = client_fread(ptr, size, n, stream);
         }
     });
     void* post_call = ({

--- a/libprobe/generator/libc_hooks_source.c
+++ b/libprobe/generator/libc_hooks_source.c
@@ -44,6 +44,8 @@ typedef void* va_list;
 typedef void* StringArray;
 typedef void* OpenNumber;
 typedef void* intptr_t;
+typedef void* clockid_t;
+typedef void* clock_t;
 
 int __type_mode_t;
 typedef int (*fn_ptr_int_void_ptr)(void*);
@@ -210,7 +212,7 @@ int dup3 (int old, int new, int flags) {
                     .dup = {
                         .src = get_open_number(old),
                         .old_dst = old_dst,
-                        .dst = new_open_number(new),
+                        .dst = new_open_number(new, false),
                         .flags = 0,
                     },
                 },
@@ -231,7 +233,7 @@ int dup (int old) {
                     .dup = {
                         .src = get_open_number(old),
                         .old_dst = old_dst,
-                        .dst = new_open_number(ret),
+                        .dst = new_open_number(ret, false),
                         .flags = 0,
                     },
                 },
@@ -289,7 +291,7 @@ int fcntl (int filedes, int command, ...) {
                         .dup = {
                             .src = get_open_number(filedes),
                             .old_dst = old_dst,
-                            .dst = new_open_number(ret),
+                            .dst = new_open_number(ret, false),
                             .flags = (command == F_DUPFD_CLOEXEC) ? O_CLOEXEC : 0,
                         },
                     },
@@ -312,7 +314,7 @@ int fchdir (int filedes) {
                     .dup = {
                         .src = get_open_number(filedes),
                         .old_dst = old_dst,
-                        .dst = new_open_number(AT_FDCWD),
+                        .dst = new_open_number(AT_FDCWD, false),
                         .flags = 0,
                     },
                 },
@@ -346,7 +348,7 @@ DIR * opendir (const char *dirname) {
                             .directory = get_open_number(AT_FDCWD),
                             .name = arena_strndup(get_data_arena(), dirname, PATH_MAX),
                         },
-                        .open_number = new_open_number(fd),
+                        .open_number = new_open_number(fd, false),
                         .inode = get_inode(fd),
                         .mode = 0,
                         /* https://github.com/esmil/musl/blob/master/src/dirent/opendir.c */
@@ -2240,7 +2242,7 @@ int pipe2(int pipefd[2], int flags) {
                             .directory = {.fd = -99, .number = 0},
                             .name = NULL,
                         },
-                        .open_number = new_open_number(pipefd[0]),
+                        .open_number = new_open_number(pipefd[0], false),
                         .inode = inode,
                         .flags = O_RDONLY,
                         .mode = 0,
@@ -2258,7 +2260,7 @@ int pipe2(int pipefd[2], int flags) {
                             .directory = {.fd = -99, .number = 0},
                             .name = NULL,
                         },
-                        .open_number = new_open_number(pipefd[1]),
+                        .open_number = new_open_number(pipefd[1], false),
                         .inode = inode,
                         .flags = O_CREAT | O_TRUNC | O_WRONLY,
                         .mode = 0,
@@ -2373,6 +2375,15 @@ int mkstemps(char *template, int suffixlen) {
 };
 
 ssize_t read(int fd, void* buf, size_t count) {
+    void* call = ({
+        ssize_t ret;
+        if (UNLIKELY(is_rand(fd))) {
+            memset(buf, 0, count);
+            ret = count;
+        } else {
+            ret = client_read(fd, buf, count);
+        }
+    });
     void* post_call = ({
         print_open_fd(fd);
         // Note that ret == 0 could mean we hit EOF
@@ -2504,6 +2515,15 @@ ssize_t copy_file_range(int fd_in, off_t* off_in, int fd_out, off_t* off_out,
 
 
 size_t fread(void* restrict ptr, size_t size, size_t n, FILE* restrict stream) {
+    void* call = ({
+        size_t ret;
+        if (UNLIKELY(is_rand(fileno(stream)))) {
+            memset(ptr, 0, n);
+            ret = n;
+        } else {
+            ret = fread(ptr, size, n, stream);
+        }
+    });
     void* post_call = ({
         int fd = fileno(stream);
         print_open_fd(fd);
@@ -2549,7 +2569,7 @@ ssize_t recvmsg(int socket, struct msghdr* message, int flags) {
                     int received_fd;
                     memcpy(&received_fd, CMSG_DATA(control_message), sizeof(received_fd));
                     print_open_fd(received_fd);
-                    OpenNumber new_on = new_open_number(received_fd);
+                    OpenNumber new_on = new_open_number(received_fd, false);
                     char proc_path[64];
                     char fd_path[PATH_MAX];
                     snprintf(proc_path, sizeof(proc_path), "/proc/self/fd/%d", received_fd);
@@ -2583,7 +2603,7 @@ ssize_t recvmsg(int socket, struct msghdr* message, int flags) {
 int socket(int domain, int type, int protocol) {
     void* post_call = ({
         if (LIKELY(ret >= 0 && prov_log_is_enabled())) {
-            OpenNumber on = new_open_number(ret);
+            OpenNumber on = new_open_number(ret, false);
             prov_log_record((struct Op) {
                 .data = {
                     .open_tag = OpData_Open,
@@ -2641,6 +2661,53 @@ int posix_spawn_file_actions_adddup2(posix_spawn_file_actions_t *file_actions, i
                 },
                 .ferrno = 0,
             });
+        }
+    });
+}
+
+ssize_t getrandom(void* buf, size_t size, unsigned int flags) {
+    void* call = ({
+        ssize_t ret;
+        if (get_fix_random()) {
+            memset(buf, 0, size);
+            ret = size;
+        } else {
+            ret = client_getrandom(buf, size, flags);
+        }
+    });
+}
+
+int getentropy(void* buffer, size_t length) {
+    void* call = ({
+        int ret;
+        if (get_fix_random()) {
+            memset(buffer, 0, length);
+            ret = length;
+        } else {
+            ret = client_getentropy(buffer, length);
+        }
+    });
+}
+
+int clock_gettime(clockid_t clockid, struct timespec* tp) {
+    void* call = ({
+        int ret;
+        if (get_fix_random()) {
+            memset(tp, 0, sizeof(struct timespec));
+            ret = 0;
+        } else {
+            ret = clock_gettime(clockid, tp);
+        }
+    });
+}
+
+clock_t clock(void) {
+    void* call = ({
+        clock_t ret;
+        if (get_fix_random()) {
+            ret = 0;
+        } else {
+            ret = client_clock();
         }
     });
 }

--- a/libprobe/generator/libc_hooks_source.c
+++ b/libprobe/generator/libc_hooks_source.c
@@ -2696,7 +2696,7 @@ int clock_gettime(clockid_t clockid, struct timespec* tp) {
             memset(tp, 0, sizeof(struct timespec));
             ret = 0;
         } else {
-            ret = clock_gettime(clockid, tp);
+            ret = client_clock_gettime(clockid, tp);
         }
     });
 }

--- a/libprobe/src/global_state.c
+++ b/libprobe/src/global_state.c
@@ -124,6 +124,10 @@ static inline const struct ProcessTreeContext* _Nonnull get_process_tree_context
     return __process_tree_context;
 }
 
+__attribute__((visibility("hidden"))) bool get_fix_random() {
+    return __process_tree_context->fix_random;
+}
+
 /*
  * Set up by CLI or previous epoch.
  * use probe_dir and pid to find this.

--- a/libprobe/src/global_state.h
+++ b/libprobe/src/global_state.h
@@ -38,6 +38,8 @@ __attribute__((visibility("hidden"))) pid_t get_tid_safe();
 
 __attribute__((visibility("hidden"))) pid_t get_tid();
 
+__attribute__((visibility("hidden"))) bool get_fix_random();
+
 __attribute__((visibility("hidden"))) const struct FixedPath* _Nonnull get_probe_dir();
 
 __attribute__((visibility("hidden"))) const struct FixedPath* _Nonnull get_libprobe_path();

--- a/libprobe/src/prov_buffer.c
+++ b/libprobe/src/prov_buffer.c
@@ -241,9 +241,10 @@ struct Inode get_inode(int fd) {
 static struct FdTable fd_table;
 
 const uint16_t MIN_OPEN_NUMBER = 3;
-const uint16_t NUMBER_MASK = 0x3FFF;
+const uint16_t NUMBER_MASK = 0x1FFF;
 const uint16_t WRITE_BIT = 0x8000;
 const uint16_t READ_BIT = 0x4000;
+const uint16_t RAND_BIT = 0x2000;
 
 OpenNumber get_open_number(int fd) {
     uint16_t number = atomic_load(fd_table_address_of_strong(&fd_table, fd));
@@ -257,7 +258,7 @@ OpenNumber reset_open_number(int fd) {
     return (OpenNumber){.fd = fd, .number = number};
 }
 
-OpenNumber new_open_number(int fd) {
+OpenNumber new_open_number(int fd, bool is_rand) {
     _Atomic(uint16_t)* address = fd_table_address_of_strong(&fd_table, fd);
     uint16_t old_number = atomic_load(address) & 0x3FFF;
     uint16_t new_number;
@@ -265,6 +266,9 @@ OpenNumber new_open_number(int fd) {
         new_number = MIN_OPEN_NUMBER;
     } else {
         new_number = old_number + 1;
+    }
+    if (UNLIKELY(is_rand)) {
+        new_number |= RAND_BIT;
     }
     atomic_store(address, new_number);
     ASSERTF(new_number >= MIN_OPEN_NUMBER, "");
@@ -282,6 +286,11 @@ void mark_access(int fd, bool is_write) {
     DEBUG("Mark %d,%d as %s", fd, number, is_write ? "write" : "read");
 #endif
     atomic_fetch_or(address, is_write ? WRITE_BIT : READ_BIT);
+}
+
+bool is_rand(int fd) {
+    _Atomic(uint16_t)* address = fd_table_address_of_strong(&fd_table, fd);
+    return atomic_load(address) & RAND_BIT;
 }
 
 int open_wrapper(int dirfd, const char* filename, int flags, mode_t mode) {
@@ -327,10 +336,18 @@ int open_wrapper(int dirfd, const char* filename, int flags, mode_t mode) {
     }
 
     if (fd >= 0) {
-        OpenNumber open_number = new_open_number(fd);
-        DEBUG("on %d,%d; inode %lu; dev=%d,%d", open_number.fd, open_number.number, inode.number,
-              inode.device_major, inode.device_minor);
+        bool is_rand =
+            get_fix_random() && inode.device_major == 0 &&
+            UNLIKELY(inode.device_minor == 6 && (inode.number == 8 || inode.number == 9));
+        OpenNumber open_number = new_open_number(fd, is_rand);
+        DEBUG("on %d,%d; inode %lu; dev=%d,%d, is_rand=%d", open_number.fd, open_number.number,
+              inode.number, inode.device_major, inode.device_minor, is_rand);
         ASSERTF(open_number.number > 0, "");
+        if (inode.device_major == 0 && inode.device_minor == 6 &&
+            (inode.number == 8 || inode.number == 9)) {
+            _Atomic(uint16_t)* address = fd_table_address_of_strong(&fd_table, fd);
+            atomic_fetch_or(address, RAND_BIT);
+        }
         prov_log_record((struct Op){
             .data =
                 {
@@ -420,9 +437,13 @@ FILE* fopen_wrapper(const char* filename, const char* opentype) {
     }
 
     if (file) {
-        OpenNumber open_number = new_open_number(fileno(file));
-        DEBUG("on %d,%d; ret=FILE %p, inode %lu; dev=%d,%d", open_number.fd, open_number.number,
-              file, inode.number, inode.device_major, inode.device_minor);
+        bool is_rand =
+            get_fix_random() && inode.device_major == 0 &&
+            UNLIKELY(inode.device_minor == 6 && (inode.number == 8 || inode.number == 9));
+        OpenNumber open_number = new_open_number(fileno(file), is_rand);
+        DEBUG("on %d,%d; ret=FILE %p, inode %lu; dev=%d,%d rand=%d", open_number.fd,
+              open_number.number, file, inode.number, inode.device_major, inode.device_minor,
+              is_rand);
         ASSERTF(open_number.number > 0, "");
         prov_log_record((struct Op){
             .data =

--- a/libprobe/src/prov_buffer.h
+++ b/libprobe/src/prov_buffer.h
@@ -27,8 +27,10 @@ __attribute__((visibility("hidden"))) struct Inode get_inode(int fd);
 __attribute__((visibility("hidden"))) FILE* fopen_wrapper(const char* filename,
                                                           const char* opentype);
 
-__attribute__((visibility("hidden"))) OpenNumber new_open_number(int fd);
+__attribute__((visibility("hidden"))) OpenNumber new_open_number(int fd, bool is_rand);
 
 __attribute__((visibility("hidden"))) OpenNumber dup_open_numbers(int old, int new);
 
 __attribute__((visibility("hidden"))) void mark_access(int fd, bool is_write);
+
+__attribute__((visibility("hidden"))) bool is_rand(int fd);

--- a/tests/test_fix_random.py
+++ b/tests/test_fix_random.py
@@ -1,0 +1,26 @@
+import subprocess
+
+def test_cat_random() -> None:
+    cmd = ["probe", "record", "--fix-random", "--overwrite", "head", "--bytes=100", "/dev/random"]
+    proc = subprocess.run(cmd, capture_output=True, check=True)
+    assert proc.stdout.strip() == b"\0" * 100
+
+
+def test_clock() -> None:
+    cmd = ["probe", "record", "--fix-random", "--overwrite", "date", "--utc", "--iso-8601=sec"]
+    proc = subprocess.run(cmd, capture_output=True, check=True)
+    assert proc.stdout == b"1970-01-01T00:00:00+00:00\n"
+
+
+def test_py_rand() -> None:
+    cmd = ["probe", "record", "--fix-random", "--overwrite", "python", "-c", "import random; print(random.random())"]
+    proc0 = subprocess.run(cmd, capture_output=True, check=True)
+    proc1 = subprocess.run(cmd, capture_output=True, check=True)
+    assert proc0.stdout == proc1.stdout
+
+
+def test_py_addresses() -> None:
+    cmd = ["probe", "record", "--fix-random", "--overwrite", "python", "-c", "print(id(object()))"]
+    proc0 = subprocess.run(cmd, capture_output=True, check=True)
+    proc1 = subprocess.run(cmd, capture_output=True, check=True)
+    assert proc0.stdout == proc1.stdout


### PR DESCRIPTION
`--fix-random` fixes random factors present (reading /dev/random, calling getrandom(), clock_gettime(), and disabling ASLR).