### PR TITLE
Minor fixes ahead of pwc2

### DIFF
--- a/cli-wrapper/probe_cli/src/record.rs
+++ b/cli-wrapper/probe_cli/src/record.rs
@@ -48,6 +48,7 @@ pub fn record_no_transcribe(
         .record()
         .wrap_err("Recorder::record")?;
 
+    std::fs::create_dir(&output)?;
     fs_extra::dir::move_dir(&dir, &output, &fs_extra::dir::CopyOptions::new()).wrap_err(eyre!(
         "moving {:?} to {:?}",
         &dir,

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -13,19 +13,21 @@ Add the following arguments to the `<FLAGS>` of `podman run <FLAGS> <IMG> [CMD]`
 ```
 --env PROBE_BUILDAH=$PROBE_BUILDAH \
 --env PROBE_LIB=$PROBE_LIB \
---env PROBE_PYTHONPATH=$PROB_PYTHONPATH \
---env PROBE_PYTHON=$PROBE_PYTHON \
+--env PROBE_PYTHONPATH=${PROBE_PYTHONPATH} \
+--env PROBE_PYTHON=${PROBE_PYTHON} \
 --env probe=$(which probe) \
---volume=$PROBE_ROOT:$PROBE_ROOT:ro \
+--volume=${PROBE_ROOT}:${PROBE_ROOT}:ro \
 --volume=/nix/store:/nix/store:ro \
+--volume=$(dirname $(which probe)):$(dirname $(which probe)):ro \
+--volume=${PROBE_LIB}:${PROBE_LIB}:ro \
 ```
 
 Once inside the container, run PROBE by `$probe record ...`. Make sure to single-quote `$probe` if you are passing it on the command-line. For example,
 
 ```
 podman run \
-    --rm \
     ... flags from earlier \
+    --rm \
     ubuntu:24.04 \
     bash -c '$probe record ls'
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -76,25 +76,6 @@
             nativeBuildInputs = [python.pkgs.setuptools];
             propagatedBuildInputs = [python.pkgs.numpy];
           };
-          datamodel-code-generator = python.pkgs.datamodel-code-generator.overridePythonAttrs (super: rec {
-            version = "0.55.0";
-            src = pkgs.fetchFromGitHub {
-              owner = "koxudaxi";
-              repo = "datamodel-code-generator";
-              tag = version;
-              hash = "sha256-zsLJv7gKhmnEIS/AUvnBzm+07QFQoMdiFo/PkfRyHek=";
-            };
-            disabledTests = [
-              "perf"
-            ];
-            nativeCheckInputs =
-              super.nativeCheckInputs
-              ++ [
-                python.pkgs.time-machine
-                python.pkgs.inline-snapshot
-                python.pkgs.watchfiles
-              ];
-          });
           inherit (cli-wrapper-pkgs) cargoArtifacts probe-cli probe-headers;
           libprobe = old-stdenv.mkDerivation rec {
             pname = "libprobe";
@@ -128,7 +109,6 @@
               pkgs.clang-tools
               pkgs.compiledb
               pkgs.cppcheck
-              pkgs.cppclean
               pkgs.include-what-you-use
             ];
             checkPhase = ''
@@ -172,7 +152,7 @@
           };
           probe-py-headers = pkgs.runCommand "probe-py-headers" {} ''
             mkdir $out
-            export PATH="${packages.datamodel-code-generator}/bin:${python}/bin/:$PATH"
+            export PATH="${pkgs.datamodel-code-generator}/bin:${python}/bin/:$PATH"
             env \
               JSONSCHEMA_OUTFILE=${probe-headers}/headers.json \
               PYTHON_HEADER_OUTFILE=$out/headers.py \
@@ -312,8 +292,9 @@
 
             # probe_py "dev time" requirements
             packages.types-networkx
-            packages.datamodel-code-generator
+            pypkgs.datamodel-code-generator
             pypkgs.ipython
+            pypkgs.ipdb
             pypkgs.mypy
             pypkgs.pytest
             pypkgs.pytest-asyncio

--- a/libprobe/generator/libc_hooks_source.c
+++ b/libprobe/generator/libc_hooks_source.c
@@ -342,8 +342,8 @@ int chdir (const char *filename) {
 /* Docs: https://www.gnu.org/software/libc/manual/html_node/Opening-a-Directory.html */
 DIR * opendir (const char *dirname) {
     void* post_call = ({
-        if (LIKELY(prov_log_is_enabled() && ret)) {
-            int fd = dirfd(ret);
+        int fd;
+        if (LIKELY(prov_log_is_enabled() && ret && (fd = dirfd(ret)) > 0)) {
             prov_log_record((struct Op){
                 .data = {
                     .open_tag = OpData_Open,
@@ -2236,9 +2236,7 @@ int munmap(void* addr, size_t length) { }
 int pipe2(int pipefd[2], int flags) {
     void* post_call = ({
         /* A successful pipe call is equivalent to two opens on a fifo file into specific FDs */
-        if (LIKELY(ret == 0)) {
-            print_open_fd(pipefd[0]);
-            print_open_fd(pipefd[1]);
+        if (LIKELY(ret == 0 && pipefd[0] > 0 && pipefd[1] > 0)) {
             struct Inode inode = get_inode(pipefd[0]);
             prov_log_record((struct Op){
                 .data = {
@@ -2287,7 +2285,7 @@ int pipe(int pipefd[2]) {
 
 int mkfifoat(int fd, const char* pathname, mode_t mode) {
     void* post_call = ({
-        if (call_errno == 0) {
+        if (call_errno == 0 && fd > 0) {
             prov_log_record((struct Op){
                 .data = {
                     .open_tag = OpData_Open,
@@ -2574,6 +2572,7 @@ ssize_t recvmsg(int socket, struct msghdr* message, int flags) {
                 if (control_message->cmsg_level == SOL_SOCKET && control_message->cmsg_type == SCM_RIGHTS) {
                     int received_fd;
                     memcpy(&received_fd, CMSG_DATA(control_message), sizeof(received_fd));
+                    ASSERTF(received_fd > 0, "fd was zero or negative");
                     print_open_fd(received_fd);
                     OpenNumber new_on = new_open_number(received_fd, false);
                     char proc_path[64];

--- a/libprobe/src/probe_libc.c
+++ b/libprobe/src/probe_libc.c
@@ -491,6 +491,12 @@ char* _Nonnull probe_libc_strndup(const char* _Nonnull s, size_t n) {
 }
 
 int probe_libc_strncmp(const char* _Nonnull a, const char* _Nonnull b, size_t maxlen) {
+    if (!a && !b) {
+        return true;
+    }
+    if (!!a ^ !!b) {
+        return false;
+    }
     size_t i = 0;
     for (; a[i] != '\0' && b[i] != '\0' && i < maxlen; ++i) {
         int_fast16_t diff = (int_fast16_t)(unsigned char)a[i] - (int_fast16_t)(unsigned char)b[i];
@@ -525,6 +531,9 @@ const char* _Nullable probe_libc_getenv(const char* _Nonnull name) {
     size_t name_len = probe_libc_strnlen(name, -1);
     for (size_t i = 0; probe_environ != NULL; ++i) {
         const char* curr = probe_environ[i];
+        if (!curr) {
+            break;
+        }
         if (probe_libc_strncmp(name, curr, name_len) == 0 && curr[name_len] == '=') {
             return curr + name_len + 1;
         }

--- a/libprobe/src/prov_buffer.c
+++ b/libprobe/src/prov_buffer.c
@@ -342,7 +342,7 @@ int open_wrapper(int dirfd, const char* filename, int flags, mode_t mode) {
         }
     }
 
-    if (fd >= 0) {
+    if (fd > 0) {
         bool is_rand =
             get_fix_random() && inode.device_major == 0 &&
             UNLIKELY(inode.device_minor == 6 && (inode.number == 8 || inode.number == 9));
@@ -443,7 +443,8 @@ FILE* fopen_wrapper(const char* filename, const char* opentype) {
         }
     }
 
-    if (file) {
+    int fd;
+    if (file && (fd = fileno(file)) > 0) {
         bool is_rand =
             get_fix_random() && inode.device_major == 0 &&
             UNLIKELY(inode.device_minor == 6 && (inode.number == 8 || inode.number == 9));

--- a/probe_py/probe_py/cli.py
+++ b/probe_py/probe_py/cli.py
@@ -178,7 +178,7 @@ def dataflow_graph(
         ignore_paths: Annotated[
             str,
             typer.Option(help="Comma-separated glob/fnmatch"),
-        ] = "/nix/store/,/dev/,/proc/,/sys/",
+        ] = "/nix/store/*,/dev/*,/proc/*,/sys/*,*.pyc,*/.local/state/nix/profile/*",
         relative_to: Annotated[
             pathlib.Path,
             typer.Option(help="Path in which to write the inodes relative to"),

--- a/probe_py/probe_py/hb_graph.py
+++ b/probe_py/probe_py/hb_graph.py
@@ -222,7 +222,7 @@ def _create_exec_edges(node: OpQuad, probe_log: ProbeLog, hb_graph: HbGraph) -> 
         next_exec_no = node.exec_no.next()
         if next_exec_no not in probe_log.processes[node.pid].execs:
             warnings.warn(ptypes.UnusualProbeLog(
-                f"Exec points to an exec epoch {next_exec_no} we didn't track"
+                f"Exec {node} points to an exec epoch {next_exec_no} we didn't track"
             ))
         else:
             target = OpQuad(node.pid, next_exec_no, node.pid.main_thread(), 0)

--- a/probe_py/probe_py/vector_clock.py
+++ b/probe_py/probe_py/vector_clock.py
@@ -8,7 +8,7 @@ import networkx
 from . import partial_order
 
 _ThreadId = typing.NewType("_ThreadId", int)
-_TimeVal: typing.TypeAlias = numpy.int16
+_TimeVal: typing.TypeAlias = numpy.int32
 
 
 # TODO: use Numpy arrays

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -60,6 +60,7 @@ example_path = pathlib.Path("../../../examples")
 
 
 simple_commands = {
+    "env-echo": ["env", "-", str(example_path / "echo.exe"), "hello", "world"],
     "echo": [str(example_path / "echo.exe"), "hello", "world"],
     "cat": [str(example_path / "cat.exe"), "test_file.txt"],
     "fcat": [str(example_path / "fcat.exe"), "test_file.txt"],


### PR DESCRIPTION
1, Create the directory for the --no-transcribe case
2. Correct directions for running PROBE in containers (accounting for non-standard CARGO_HOMEs)
3. Delete `cppclean` (no longer needed)
4. Don't use a custom version of datamodel-code-generator (the nixpkgs works fine now)
5. Add ipdb (used for debugging)
6. Make sure only positive FDs (indicating success) cause events to be logged.
7. Fix bugs in strncmp and getenv. Add an example that clears out the env (which would trigger this bug).
8. Fix ignore paths
9. Add better debug messages
10. Use 32 instead of 16 bit ints for the Vector clocks. Needed because some PWC examples have a ton of events.